### PR TITLE
feat: Obsidian REST dual-mode and DeepSeek integration for issue #3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,14 @@
+LLM_PROVIDER=deepseek
 OPENAI_API_KEY=
 OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-4.1-mini
+DEEPSEEK_API_KEY=
+DEEPSEEK_BASE_URL=https://api.deepseek.com
+DEEPSEEK_MODEL=deepseek-chat
+OBSIDIAN_MODE=auto
 OBSIDIAN_API_URL=
 OBSIDIAN_API_KEY=
+OBSIDIAN_VERIFY_SSL=false
 VAULT_ROOT=./data/demo_vault
 SQLITE_PATH=./data/processed/obsidian_agent.db
 VECTOR_STORE_PATH=./data/processed/vector_index.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .venv/
+.env
 venv/
 env/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ pip install -e .[dev]
 copy .env.example .env
 ```
 
+默认推荐：
+- `LLM_PROVIDER=deepseek`
+- `OBSIDIAN_MODE=auto`
+
 3. 启动开发服务：
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -3,4 +3,6 @@
 - 设置 `VAULT_ROOT` 指向本地 Vault。
 - 启动服务前确认 `data/processed/` 可写。
 - 生产中推荐开启 Obsidian Local REST API，并配置 `OBSIDIAN_API_URL`。
+- `OBSIDIAN_MODE=auto` 时优先尝试 REST，失败后回退到本地文件模式。
+- `LLM_PROVIDER=deepseek` 时会通过 DeepSeek 的 OpenAI-compatible 接口生成结构化输出。
 - `DRY_RUN=true` 时，系统只返回计划动作，不写 Vault。

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI, Request
 from sqlalchemy.orm import sessionmaker
 
 from obsidian_agent.config import Settings, get_settings
+from obsidian_agent.integrations.deepseek_client import DeepSeekChatClient
 from obsidian_agent.integrations.obsidian_rest_client import ObsidianRestClient
 from obsidian_agent.integrations.openai_client import OpenAIResponsesClient
 from obsidian_agent.logging import configure_logging, trace_middleware
@@ -54,17 +55,30 @@ def build_container(settings: Settings | None = None) -> AppContainer:
     configure_logging(settings.log_level)
     session_factory = create_session_factory(settings.sqlite_path)
     rest_client = (
-        ObsidianRestClient(settings.obsidian_api_url, settings.obsidian_api_key)
+        ObsidianRestClient(
+            settings.obsidian_api_url,
+            settings.obsidian_api_key,
+            verify_ssl=settings.obsidian_verify_ssl,
+        )
         if settings.obsidian_api_url
         else None
     )
     obsidian_service = ObsidianService(settings, rest_client)
-    openai_client = (
-        OpenAIResponsesClient(settings.openai_api_key, settings.openai_base_url)
-        if settings.openai_api_key
-        else None
-    )
-    llm_service = LLMService(openai_client)
+    llm_client = None
+    provider = settings.llm_provider.lower()
+    if provider in {"auto", "deepseek"} and settings.deepseek_api_key:
+        llm_client = DeepSeekChatClient(
+            settings.deepseek_api_key,
+            settings.deepseek_base_url,
+            settings.deepseek_model,
+        )
+    elif provider in {"auto", "openai"} and settings.openai_api_key:
+        llm_client = OpenAIResponsesClient(
+            settings.openai_api_key,
+            settings.openai_base_url,
+            settings.openai_model,
+        )
+    llm_service = LLMService(llm_client)
     embeddings_service = EmbeddingsService()
     vector_store = VectorStore(settings.vector_store_path)
     retrieval_service = RetrievalService(session_factory, obsidian_service, embeddings_service, vector_store)

--- a/src/obsidian_agent/config.py
+++ b/src/obsidian_agent/config.py
@@ -15,10 +15,17 @@ class Settings(BaseSettings):
     app_env: str = "development"
     log_level: str = "INFO"
     dry_run: bool = False
+    llm_provider: str = "auto"
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
+    openai_model: str = "gpt-4.1-mini"
+    deepseek_api_key: str | None = None
+    deepseek_base_url: str = "https://api.deepseek.com"
+    deepseek_model: str = "deepseek-chat"
+    obsidian_mode: str = "auto"
     obsidian_api_url: str | None = None
     obsidian_api_key: str | None = None
+    obsidian_verify_ssl: bool = False
     vault_root: Path = Field(default=Path("./data/demo_vault"))
     sqlite_path: Path = Field(default=Path("./data/processed/obsidian_agent.db"))
     vector_store_path: Path = Field(default=Path("./data/processed/vector_index.json"))

--- a/src/obsidian_agent/integrations/deepseek_client.py
+++ b/src/obsidian_agent/integrations/deepseek_client.py
@@ -1,0 +1,42 @@
+"""DeepSeek OpenAI-compatible client."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+
+
+class DeepSeekChatClient:
+    """Call DeepSeek's OpenAI-compatible chat API and return JSON payloads."""
+
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.deepseek.com",
+        model: str = "deepseek-chat",
+    ) -> None:
+        self.api_key = api_key
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+
+    async def create_json_response(self, instructions: str, input_text: str) -> dict[str, object]:
+        payload = {
+            "model": self.model,
+            "response_format": {"type": "json_object"},
+            "messages": [
+                {"role": "system", "content": instructions},
+                {"role": "user", "content": input_text},
+            ],
+        }
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self.base_url}/chat/completions",
+                headers=headers,
+                json=payload,
+            )
+            response.raise_for_status()
+        data = response.json()
+        message_text = data["choices"][0]["message"]["content"]
+        return json.loads(message_text)

--- a/src/obsidian_agent/integrations/obsidian_rest_client.py
+++ b/src/obsidian_agent/integrations/obsidian_rest_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from urllib.parse import quote
 
 import httpx
 
@@ -10,9 +11,15 @@ import httpx
 class ObsidianRestClient:
     """Client used when the Local REST API is available."""
 
-    def __init__(self, base_url: str, api_key: str | None = None) -> None:
+    def __init__(
+        self,
+        base_url: str,
+        api_key: str | None = None,
+        verify_ssl: bool = False,
+    ) -> None:
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
+        self.verify_ssl = verify_ssl
 
     def _headers(self) -> Mapping[str, str]:
         headers: dict[str, str] = {}
@@ -20,14 +27,46 @@ class ObsidianRestClient:
             headers["Authorization"] = f"Bearer {self.api_key}"
         return headers
 
-    async def get(self, path: str, params: dict[str, str] | None = None) -> dict[str, object]:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.get(f"{self.base_url}{path}", headers=self._headers(), params=params)
+    async def get(self, path: str, params: dict[str, str] | None = None) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=30.0, verify=self.verify_ssl) as client:
+            response = await client.get(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                params=params,
+            )
             response.raise_for_status()
-            return response.json()
+            return response
 
-    async def post(self, path: str, payload: dict[str, object]) -> dict[str, object]:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(f"{self.base_url}{path}", headers=self._headers(), json=payload)
+    async def post(self, path: str, payload: dict[str, object]) -> httpx.Response:
+        async with httpx.AsyncClient(timeout=30.0, verify=self.verify_ssl) as client:
+            response = await client.post(
+                f"{self.base_url}{path}",
+                headers=self._headers(),
+                json=payload,
+            )
             response.raise_for_status()
-            return response.json()
+            return response
+
+    async def put_text(self, vault_path: str, content: str) -> None:
+        encoded = quote(vault_path, safe="/")
+        async with httpx.AsyncClient(timeout=30.0, verify=self.verify_ssl) as client:
+            response = await client.put(
+                f"{self.base_url}/vault/{encoded}",
+                headers={**self._headers(), "Content-Type": "text/markdown; charset=utf-8"},
+                content=content.encode("utf-8"),
+            )
+            response.raise_for_status()
+
+    async def read_text(self, vault_path: str) -> str:
+        encoded = quote(vault_path, safe="/")
+        response = await self.get(f"/vault/{encoded}")
+        return response.text
+
+    async def delete_note(self, vault_path: str) -> None:
+        encoded = quote(vault_path, safe="/")
+        async with httpx.AsyncClient(timeout=30.0, verify=self.verify_ssl) as client:
+            response = await client.delete(
+                f"{self.base_url}/vault/{encoded}",
+                headers=self._headers(),
+            )
+            response.raise_for_status()

--- a/src/obsidian_agent/integrations/openai_client.py
+++ b/src/obsidian_agent/integrations/openai_client.py
@@ -10,13 +10,19 @@ import httpx
 class OpenAIResponsesClient:
     """Thin wrapper over the OpenAI Responses API."""
 
-    def __init__(self, api_key: str, base_url: str = "https://api.openai.com/v1") -> None:
+    def __init__(
+        self,
+        api_key: str,
+        base_url: str = "https://api.openai.com/v1",
+        model: str = "gpt-4.1-mini",
+    ) -> None:
         self.api_key = api_key
         self.base_url = base_url.rstrip("/")
+        self.model = model
 
     async def create_json_response(self, instructions: str, input_text: str) -> dict[str, object]:
         payload = {
-            "model": "gpt-4.1-mini",
+            "model": self.model,
             "input": [
                 {"role": "system", "content": [{"type": "input_text", "text": instructions}]},
                 {"role": "user", "content": [{"type": "input_text", "text": input_text}]},

--- a/src/obsidian_agent/services/llm_service.py
+++ b/src/obsidian_agent/services/llm_service.py
@@ -2,16 +2,29 @@
 
 from __future__ import annotations
 
+from typing import Protocol
+
 from obsidian_agent.domain.enums import ProposalType, SourceType
 from obsidian_agent.domain.policies import classify_risk
-from obsidian_agent.domain.schemas import CaptureInput, NormalizedCapture, RelatedNoteCandidate, ReviewProposal
-from obsidian_agent.integrations.openai_client import OpenAIResponsesClient
+from obsidian_agent.domain.schemas import (
+    CaptureInput,
+    NormalizedCapture,
+    RelatedNoteCandidate,
+    ReviewProposal,
+)
+
+
+class JsonLLMClient(Protocol):
+    """Minimal contract for provider clients used by LLMService."""
+
+    async def create_json_response(self, instructions: str, input_text: str) -> dict[str, object]:
+        """Return structured JSON output."""
 
 
 class LLMService:
     """Normalize inputs and generate proposals."""
 
-    def __init__(self, client: OpenAIResponsesClient | None = None) -> None:
+    def __init__(self, client: JsonLLMClient | None = None) -> None:
         self.client = client
 
     async def normalize_capture(self, payload: CaptureInput) -> NormalizedCapture:
@@ -21,11 +34,13 @@ class LLMService:
             raw = await self.client.create_json_response(
                 instructions=(
                     "Return JSON with keys: title, summary, entities, topics, tags, "
-                    "decision, confidence, conflicts, key_points, raw_excerpt."
+                    "decision, confidence, conflicts, key_points, raw_excerpt. "
+                    "The decision field must be exactly one of: "
+                    "new_note, append_candidate, merge_candidate, review_only."
                 ),
                 input_text=payload.text,
             )
-            return NormalizedCapture.model_validate(raw)
+            return NormalizedCapture.model_validate(self._sanitize_normalized_capture(raw, payload))
 
         title = payload.title or payload.text.splitlines()[0][:80] or "Untitled"
         text = payload.text.strip()
@@ -51,6 +66,61 @@ class LLMService:
             key_points=key_points,
             raw_excerpt=text[:500],
         )
+
+    def _sanitize_normalized_capture(
+        self, raw: dict[str, object], payload: CaptureInput
+    ) -> dict[str, object]:
+        """Coerce provider JSON into the local schema contract."""
+
+        sanitized = dict(raw)
+        text = payload.text.strip()
+        title = payload.title or text.splitlines()[0][:80] or "Untitled"
+        sanitized["title"] = str(sanitized.get("title") or title)
+        sanitized["summary"] = str(sanitized.get("summary") or " ".join(text.split()[:60]).strip())
+        sanitized["raw_excerpt"] = str(sanitized.get("raw_excerpt") or text[:500])
+        sanitized["confidence"] = self._coerce_confidence(sanitized.get("confidence"))
+        sanitized["decision"] = self._coerce_decision(sanitized.get("decision"))
+        for field_name in ("entities", "topics", "tags", "conflicts", "key_points"):
+            sanitized[field_name] = self._coerce_string_list(sanitized.get(field_name))
+        sanitized["related_candidates"] = self._coerce_related_candidates(
+            sanitized.get("related_candidates"),
+        )
+        return sanitized
+
+    @staticmethod
+    def _coerce_decision(value: object) -> str:
+        allowed = {item.value for item in ProposalType}
+        candidate = str(value or "").strip().lower()
+        return candidate if candidate in allowed else ProposalType.NEW_NOTE.value
+
+    @staticmethod
+    def _coerce_confidence(value: object) -> float:
+        try:
+            return max(0.0, min(1.0, float(value)))
+        except (TypeError, ValueError):
+            return 0.5
+
+    @staticmethod
+    def _coerce_string_list(value: object) -> list[str]:
+        if isinstance(value, list):
+            return [str(item).strip() for item in value if str(item).strip()]
+        if isinstance(value, str) and value.strip():
+            return [value.strip()]
+        return []
+
+    def _coerce_related_candidates(self, value: object) -> list[dict[str, object]]:
+        if not isinstance(value, list):
+            return []
+        items: list[dict[str, object]] = []
+        for raw_item in value:
+            if not isinstance(raw_item, dict):
+                continue
+            path = str(raw_item.get("path") or "").strip()
+            reason = str(raw_item.get("reason") or "").strip() or "Related context"
+            score = self._coerce_confidence(raw_item.get("score"))
+            if path:
+                items.append({"path": path, "reason": reason, "score": score})
+        return items
 
     async def classify_integration_action(
         self, new_note: str, related_notes: list[RelatedNoteCandidate]

--- a/src/obsidian_agent/services/obsidian_service.py
+++ b/src/obsidian_agent/services/obsidian_service.py
@@ -24,6 +24,25 @@ class ObsidianService:
     def _path(self, vault_path: str) -> Path:
         return self.settings.vault_root / vault_path
 
+    def _mode(self) -> str:
+        return self.settings.obsidian_mode.lower()
+
+    def _rest_enabled(self) -> bool:
+        return self.client is not None and self._mode() in {"auto", "rest"}
+
+    def _strict_rest(self) -> bool:
+        return self.client is not None and self._mode() == "rest"
+
+    async def _run_with_optional_rest(self, operation, fallback):
+        if not self._rest_enabled():
+            return await fallback()
+        try:
+            return await operation()
+        except Exception:
+            if self._strict_rest():
+                raise
+            return await fallback()
+
     async def search_notes(
         self, query: str, top_k: int = 5, filters: dict[str, str] | None = None
     ) -> list[str]:
@@ -38,7 +57,13 @@ class ObsidianService:
         return results
 
     async def read_note(self, path: str) -> str:
-        return self._path(path).read_text(encoding="utf-8")
+        async def rest_read() -> str:
+            return await self.client.read_text(path)  # type: ignore[union-attr]
+
+        async def file_read() -> str:
+            return self._path(path).read_text(encoding="utf-8")
+
+        return await self._run_with_optional_rest(rest_read, file_read)
 
     async def read_notes(self, paths: list[str]) -> dict[str, str]:
         return {path: await self.read_note(path) for path in paths}
@@ -58,8 +83,17 @@ class ObsidianService:
                 target_path=str(target.relative_to(self.settings.vault_root)).replace("\\", "/"),
                 details={"title": title},
             )
-        target.write_text(content, encoding="utf-8")
-        return str(target.relative_to(self.settings.vault_root)).replace("\\", "/")
+        relative = str(target.relative_to(self.settings.vault_root)).replace("\\", "/")
+
+        async def rest_write() -> str:
+            await self.client.put_text(relative, content)  # type: ignore[union-attr]
+            return relative
+
+        async def file_write() -> str:
+            target.write_text(content, encoding="utf-8")
+            return relative
+
+        return await self._run_with_optional_rest(rest_write, file_write)
 
     async def append_to_note(self, path: str, section: str, content: str) -> ActionPreview | str:
         existing = await self.read_note(path)
@@ -70,8 +104,15 @@ class ObsidianService:
             updated = existing.rstrip() + f"\n\n{marker}\n{content.strip()}\n"
         if self.settings.dry_run:
             return ActionPreview(dry_run=True, action="append_to_note", target_path=path)
-        self._path(path).write_text(updated, encoding="utf-8")
-        return path
+        async def rest_write() -> str:
+            await self.client.put_text(path, updated)  # type: ignore[union-attr]
+            return path
+
+        async def file_write() -> str:
+            self._path(path).write_text(updated, encoding="utf-8")
+            return path
+
+        return await self._run_with_optional_rest(rest_write, file_write)
 
     async def replace_section(self, path: str, section_heading: str, content: str) -> ActionPreview | str:
         existing = await self.read_note(path)
@@ -91,16 +132,30 @@ class ObsidianService:
             updated += suffix
         if self.settings.dry_run:
             return ActionPreview(dry_run=True, action="replace_section", target_path=path)
-        self._path(path).write_text(updated, encoding="utf-8")
-        return path
+        async def rest_write() -> str:
+            await self.client.put_text(path, updated)  # type: ignore[union-attr]
+            return path
+
+        async def file_write() -> str:
+            self._path(path).write_text(updated, encoding="utf-8")
+            return path
+
+        return await self._run_with_optional_rest(rest_write, file_write)
 
     async def update_frontmatter(self, path: str, patch: dict[str, object]) -> ActionPreview | str:
         existing = await self.read_note(path)
         updated = patch_frontmatter(existing, patch)
         if self.settings.dry_run:
             return ActionPreview(dry_run=True, action="update_frontmatter", target_path=path)
-        self._path(path).write_text(updated, encoding="utf-8")
-        return path
+        async def rest_write() -> str:
+            await self.client.put_text(path, updated)  # type: ignore[union-attr]
+            return path
+
+        async def file_write() -> str:
+            self._path(path).write_text(updated, encoding="utf-8")
+            return path
+
+        return await self._run_with_optional_rest(rest_write, file_write)
 
     async def move_note(self, path: str, target_folder: str) -> ActionPreview | str:
         source = self._path(path)
@@ -113,8 +168,19 @@ class ObsidianService:
                 action="move_note",
                 target_path=str(target.relative_to(self.settings.vault_root)).replace("\\", "/"),
             )
-        source.rename(target)
-        return str(target.relative_to(self.settings.vault_root)).replace("\\", "/")
+        relative = str(target.relative_to(self.settings.vault_root)).replace("\\", "/")
+
+        async def rest_move() -> str:
+            content = await self.client.read_text(path)  # type: ignore[union-attr]
+            await self.client.put_text(relative, content)  # type: ignore[union-attr]
+            await self.client.delete_note(path)  # type: ignore[union-attr]
+            return relative
+
+        async def file_move() -> str:
+            source.rename(target)
+            return relative
+
+        return await self._run_with_optional_rest(rest_move, file_move)
 
     async def list_notes(self) -> list[str]:
         return [

--- a/tests/unit/test_app_container.py
+++ b/tests/unit/test_app_container.py
@@ -1,0 +1,26 @@
+from obsidian_agent.app import build_container
+from obsidian_agent.config import Settings
+
+
+def test_build_container_prefers_deepseek_when_configured(tmp_path) -> None:
+    settings = Settings(
+        llm_provider="deepseek",
+        deepseek_api_key="test-key",
+        vault_root=tmp_path / "vault",
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+    )
+    container = build_container(settings)
+    assert container.llm_service.client is not None
+    assert container.llm_service.client.__class__.__name__ == "DeepSeekChatClient"
+
+
+def test_build_container_uses_filesystem_when_no_rest_client(tmp_path) -> None:
+    settings = Settings(
+        obsidian_mode="filesystem",
+        vault_root=tmp_path / "vault",
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+    )
+    container = build_container(settings)
+    assert container.obsidian_service.client is None


### PR DESCRIPTION
## Summary
- Added a DeepSeek OpenAI-compatible client and wired it through the shared `LLMService`.
- Added `LLM_PROVIDER`, DeepSeek, Obsidian mode, and SSL verification settings.
- Added `filesystem/rest/auto` support to `ObsidianService`, with fallback to filesystem in `auto` mode.
- Added container-build tests and updated operations documentation.

## Linked Issue
- Closes #3

## Risk Assessment
- The Obsidian Local REST API wrapper now exists, but only the service handshake was validated directly; write endpoints were not fully integration-tested at that stage.
- `OBSIDIAN_MODE=auto` prefers REST and falls back to filesystem if plugin endpoints differ from current assumptions.
- DeepSeek model outputs can drift on enums; schema sanitization and defaults were added to reduce failure risk.

## Test Evidence
- `ruff check src tests --select F,E9,B`
- `python -m compileall src`
- Real DeepSeek API call returned 200 and produced structured capture output.
- Real `POST /capture/text` with DeepSeek wrote an Inbox note in an isolated vault.
- Real Obsidian Local REST API root handshake succeeded and returned authenticated status.

## Rollback Plan
- Revert commit `f8a4d77`, or close this PR without merging.