### PR TITLE
feat: complete Phase 3 capture workflows for issue #5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ copy .env.example .env
 - `LLM_PROVIDER=deepseek`
 - `OBSIDIAN_MODE=auto`
 
+说明：
+- `OBSIDIAN_MODE=filesystem` 时，系统直接使用 `VAULT_ROOT` 本地读写。
+- `OBSIDIAN_MODE=rest` 或 `auto` 且 REST 写入成功时，实际目标 Vault 由 Obsidian 当前打开的 Vault 决定，不以 `VAULT_ROOT` 为准。
+
 3. 启动开发服务：
 
 ```bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -4,5 +4,6 @@
 - 启动服务前确认 `data/processed/` 可写。
 - 生产中推荐开启 Obsidian Local REST API，并配置 `OBSIDIAN_API_URL`。
 - `OBSIDIAN_MODE=auto` 时优先尝试 REST，失败后回退到本地文件模式。
+- `OBSIDIAN_MODE=rest` 或 `auto` 成功走 REST 时，实际写入目标是 Obsidian 当前打开的 Vault；此时 `VAULT_ROOT` 仅用于文件模式和回退模式。
 - `LLM_PROVIDER=deepseek` 时会通过 DeepSeek 的 OpenAI-compatible 接口生成结构化输出。
 - `DRY_RUN=true` 时，系统只返回计划动作，不写 Vault。

--- a/src/obsidian_agent/services/capture_service.py
+++ b/src/obsidian_agent/services/capture_service.py
@@ -37,9 +37,18 @@ class CaptureService:
             job_repo.set_state(job.id, JobState.RUNNING)
             try:
                 normalized = await self.llm_service.normalize_capture(payload)
-                path = await self._write_inbox(payload, normalized)
+                write_result = await self._write_inbox(payload, normalized)
                 job_repo.set_state(job.id, JobState.SUCCEEDED)
-                return {"job_id": job.id, "note_path": path, "normalized": normalized.model_dump(mode="json")}
+                response_payload = {
+                    "job_id": job.id,
+                    "normalized": normalized.model_dump(mode="json"),
+                }
+                if hasattr(write_result, "model_dump"):
+                    response_payload["note_path"] = write_result.target_path
+                    response_payload["action_preview"] = write_result.model_dump(mode="json")
+                else:
+                    response_payload["note_path"] = write_result
+                return response_payload
             except Exception as exc:
                 job_repo.set_state(job.id, JobState.FAILED, str(exc))
                 raise

--- a/tests/integration/test_capture_flow.py
+++ b/tests/integration/test_capture_flow.py
@@ -25,3 +25,4 @@ def test_capture_text_creates_inbox_note(tmp_path: Path) -> None:
     assert "00 Inbox/" in note_path
     created = (settings.vault_root / note_path).read_text(encoding="utf-8")
     assert "# Test" in created
+    assert "kind: inbox" in created

--- a/tests/integration/test_capture_variants.py
+++ b/tests/integration/test_capture_variants.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import build_container, create_app
+from obsidian_agent.config import Settings
+from obsidian_agent.domain.models import IngestionJob
+
+
+def _build_client(tmp_path: Path, dry_run: bool = False) -> tuple[TestClient, Settings]:
+    settings = Settings(
+        vault_root=tmp_path / "vault",
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+        dry_run=dry_run,
+        obsidian_mode="filesystem",
+    )
+    app = create_app()
+    app.state.container = build_container(settings)
+    return TestClient(app), settings
+
+
+def test_capture_clipboard_creates_inbox_note(tmp_path: Path) -> None:
+    client, settings = _build_client(tmp_path)
+    response = client.post("/capture/clipboard", json={"text": "Clipboard content about structured capture."})
+    assert response.status_code == 200
+    payload = response.json()
+    note_path = payload["note_path"]
+    created = (settings.vault_root / note_path).read_text(encoding="utf-8")
+    assert "Clipboard content" in created
+
+
+def test_capture_pdf_text_creates_inbox_note(tmp_path: Path) -> None:
+    client, settings = _build_client(tmp_path)
+    response = client.post(
+        "/capture/pdf-text",
+        json={
+            "title": "Paper Notes",
+            "text": "PDF extracted text about a paper and its findings.",
+            "source_ref": "paper.pdf",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    created = (settings.vault_root / payload["note_path"]).read_text(encoding="utf-8")
+    assert "# Paper Notes" in created
+    assert "paper.pdf" in created
+
+
+def test_capture_url_uses_fetcher_output(tmp_path: Path, monkeypatch) -> None:
+    client, settings = _build_client(tmp_path)
+
+    async def fake_fetch(url: str) -> tuple[str, str]:
+        assert url == "https://example.com/article"
+        return "Example Article", "Example article body about systems and notes."
+
+    monkeypatch.setattr("obsidian_agent.api.routes_capture.fetch_url_text", fake_fetch)
+    response = client.post("/capture/url", json={"url": "https://example.com/article"})
+    assert response.status_code == 200
+    payload = response.json()
+    created = (settings.vault_root / payload["note_path"]).read_text(encoding="utf-8")
+    assert "# Example Article" in created
+    assert "https://example.com/article" in created
+
+
+def test_capture_dry_run_returns_action_preview_without_writing(tmp_path: Path) -> None:
+    client, settings = _build_client(tmp_path, dry_run=True)
+    response = client.post("/capture/text", json={"title": "Dry Run", "text": "This should not write to disk."})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["action_preview"]["dry_run"] is True
+    assert not (settings.vault_root / payload["note_path"]).exists()
+
+
+def test_capture_persists_ingestion_job_state(tmp_path: Path) -> None:
+    client, settings = _build_client(tmp_path)
+    response = client.post("/capture/text", json={"title": "Job State", "text": "Persist job state."})
+    assert response.status_code == 200
+    payload = response.json()
+    container = build_container(settings)
+    with container.session_factory() as session:
+        job = session.get(IngestionJob, payload["job_id"])
+        assert job is not None
+        assert job.state == "succeeded"


### PR DESCRIPTION
## Summary
- Completed the `text`, `url`, `clipboard`, and `pdf-text` capture paths.
- Added `action_preview` for dry-run capture results so dry-run responses are not mistaken for persisted notes.
- Added capture-variant integration tests and ingestion job success-state validation.
- Updated docs to clarify the difference between `filesystem` mode and `rest/auto` mode for `VAULT_ROOT`.

## Linked Issue
- Closes #5

## Risk Assessment
- Real Obsidian Local REST writes were validated with `204 No Content`, but the plugin's active vault can differ from the local `VAULT_ROOT`, so filesystem checks cannot be treated as the source of truth after a REST write succeeds.
- Full pytest exits remain unstable on this machine because of temp-directory permissions; the main Phase 3 paths were validated with `ruff`, `compileall`, and manual end-to-end smoke tests.

## Test Evidence
- `ruff check src tests --select F,E9,B`
- `python -m compileall src`
- Manual smoke: `/capture/text`, `/capture/url`, `/capture/clipboard`, and `/capture/pdf-text` all wrote successfully in an isolated vault.
- Real DeepSeek-backed `POST /capture/text` succeeded.
- Real Obsidian Local REST write to `PUT /vault/...` returned `204 No Content`.

## Rollback Plan
- Revert commit `45586d1`, or close this PR without merging.