### PR TITLE
feat: implement Phase 4 retrieval and linking for issue #7

### DIFF
--- a/src/obsidian_agent/services/indexing_service.py
+++ b/src/obsidian_agent/services/indexing_service.py
@@ -33,6 +33,8 @@ class IndexingService:
         indexed: list[str] = []
         with self.session_factory() as session:
             repo = NoteRepository(session)
+            repo.delete_missing(set(paths))
+            self.vector_store.clear()
             for path in paths:
                 frontmatter, body = await self.obsidian_service.parse_note(path)
                 content_hash = hashlib.sha256(body.encode("utf-8")).hexdigest()

--- a/src/obsidian_agent/services/retrieval_service.py
+++ b/src/obsidian_agent/services/retrieval_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from sqlalchemy.orm import sessionmaker
 
 from obsidian_agent.domain.schemas import RelatedNoteCandidate
@@ -27,18 +29,22 @@ class RetrievalService:
         self.vector_store = vector_store
 
     async def keyword_search(self, text: str, top_k: int = 5) -> list[RelatedNoteCandidate]:
+        query_tokens = self._tokenize(text)
         with self.session_factory() as session:
             repo = NoteRepository(session)
             scored: list[RelatedNoteCandidate] = []
             for note in repo.list_all():
-                haystack = f"{note.title} {note.source_ref or ''}".lower()
-                overlap = sum(1 for token in text.lower().split() if token in haystack)
+                note_text = await self.obsidian_service.read_note(note.vault_path)
+                haystack = f"{note.title} {note.source_ref or ''} {note_text}".lower()
+                overlap_tokens = [token for token in query_tokens if token in haystack]
+                overlap = len(set(overlap_tokens))
                 if overlap:
+                    matched = ", ".join(sorted(set(overlap_tokens))[:3])
                     scored.append(
                         RelatedNoteCandidate(
                             path=note.vault_path,
-                            reason="Keyword overlap",
-                            score=min(1.0, overlap / max(len(text.split()), 1) + 0.2),
+                            reason=f"Keyword overlap: {matched}",
+                            score=min(1.0, overlap / max(len(query_tokens), 1) + 0.25),
                         )
                     )
             return sorted(scored, key=lambda item: item.score, reverse=True)[:top_k]
@@ -60,12 +66,21 @@ class RetrievalService:
             score = ((kw.score if kw else 0.0) * 0.45) + ((sem.score if sem else 0.0) * 0.55)
             reason_parts = []
             if kw:
-                reason_parts.append("keyword")
+                reason_parts.append(kw.reason)
             if sem:
-                reason_parts.append("semantic")
-            merged[path] = RelatedNoteCandidate(path=path, reason="+".join(reason_parts), score=score)
+                reason_parts.append(f"Semantic similarity {sem.score:.2f}")
+            merged[path] = RelatedNoteCandidate(
+                path=path,
+                reason="; ".join(reason_parts),
+                score=score,
+            )
         return sorted(merged.values(), key=lambda item: item.score, reverse=True)[:top_k]
 
     async def find_related_notes(self, note_path: str, top_k: int = 5) -> list[RelatedNoteCandidate]:
         content = await self.obsidian_service.read_note(note_path)
-        return await self.hybrid_search(content, top_k=top_k)
+        related = await self.hybrid_search(content, top_k=top_k + 1)
+        return [item for item in related if item.path != note_path][:top_k]
+
+    @staticmethod
+    def _tokenize(text: str) -> list[str]:
+        return re.findall(r"[a-zA-Z0-9][a-zA-Z0-9_-]{2,}", text.lower())

--- a/src/obsidian_agent/storage/repositories.py
+++ b/src/obsidian_agent/storage/repositories.py
@@ -58,6 +58,15 @@ class NoteRepository:
     def get_by_path(self, vault_path: str) -> NoteRecord | None:
         return self.session.scalar(select(NoteRecord).where(NoteRecord.vault_path == vault_path))
 
+    def delete_missing(self, active_paths: set[str]) -> None:
+        """Remove stale metadata rows that no longer exist in the vault."""
+
+        rows = list(self.session.scalars(select(NoteRecord)).all())
+        for row in rows:
+            if row.vault_path not in active_paths:
+                self.session.delete(row)
+        self.session.commit()
+
 
 class IngestionJobRepository:
     """Capture job state repository."""

--- a/src/obsidian_agent/storage/vector_store.py
+++ b/src/obsidian_agent/storage/vector_store.py
@@ -27,6 +27,11 @@ class VectorStore:
         payload[key] = vector
         self._save(payload)
 
+    def clear(self) -> None:
+        """Reset the vector store."""
+
+        self._save({})
+
     def search(self, vector: list[float], top_k: int = 5) -> list[tuple[str, float]]:
         payload = self._load()
         scored: list[tuple[str, float]] = []

--- a/tests/fixtures/retrieval/00 Inbox/new-capture.md
+++ b/tests/fixtures/retrieval/00 Inbox/new-capture.md
@@ -1,0 +1,11 @@
+---
+id: fixture-inbox
+kind: inbox
+status: inbox
+source_type: manual
+source_ref:
+---
+
+# Retrieval Capture Candidate
+
+This new note is about semantic search, retrieval quality, and note linking in an Obsidian workflow.

--- a/tests/fixtures/retrieval/02 Literature/rag-pipeline.md
+++ b/tests/fixtures/retrieval/02 Literature/rag-pipeline.md
@@ -1,0 +1,12 @@
+---
+id: fixture-rag
+kind: literature
+status: stable
+source_type: manual
+source_ref: https://example.com/rag
+---
+
+# Retrieval Augmented Generation
+
+Retrieval augmented generation combines semantic search, embeddings, and context assembly.
+Good retrieval pipelines often mix keyword search with vector similarity.

--- a/tests/fixtures/retrieval/03 Projects/obsidian-agent.md
+++ b/tests/fixtures/retrieval/03 Projects/obsidian-agent.md
@@ -1,0 +1,12 @@
+---
+id: fixture-obsidian-agent
+kind: project
+status: draft
+source_type: manual
+source_ref:
+---
+
+# Obsidian Agent Project
+
+The Obsidian agent links notes, captures new inputs, and generates review suggestions.
+Its workflows use indexing, related note retrieval, and synthesis.

--- a/tests/fixtures/retrieval/04 Evergreen/knowledge-graph.md
+++ b/tests/fixtures/retrieval/04 Evergreen/knowledge-graph.md
@@ -1,0 +1,12 @@
+---
+id: fixture-kg
+kind: evergreen
+status: stable
+source_type: manual
+source_ref:
+---
+
+# Knowledge Graphs
+
+Knowledge graphs connect entities, concepts, and relationships across notes.
+Entity linking and graph-based retrieval improve structured knowledge navigation.

--- a/tests/integration/test_retrieval_flow.py
+++ b/tests/integration/test_retrieval_flow.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+from shutil import copytree
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import build_container, create_app
+from obsidian_agent.config import Settings
+
+
+def _build_indexed_client(tmp_path: Path):
+    fixture_root = Path("tests/fixtures/retrieval")
+    vault_root = tmp_path / "vault"
+    copytree(fixture_root, vault_root)
+    settings = Settings(
+        obsidian_mode="filesystem",
+        vault_root=vault_root,
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+    )
+    app = create_app()
+    container = build_container(settings)
+    app.state.container = container
+    client = TestClient(app)
+    return client, container
+
+
+def test_search_returns_keyword_and_semantic_results(tmp_path: Path) -> None:
+    client, container = _build_indexed_client(tmp_path)
+    asyncio.run(container.indexing_service.reindex_all())
+    response = client.get("/search", params={"q": "semantic search retrieval for notes"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["results"]
+    top_paths = [item["path"] for item in payload["results"]]
+    assert "02 Literature/rag-pipeline.md" in top_paths
+
+
+def test_find_related_notes_excludes_source_note(tmp_path: Path) -> None:
+    client, container = _build_indexed_client(tmp_path)
+    asyncio.run(container.indexing_service.reindex_all())
+    response = client.get("/notes/related", params={"path": "00 Inbox/new-capture.md"})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["results"]
+    assert all(item["path"] != "00 Inbox/new-capture.md" for item in payload["results"])
+    assert any("Semantic similarity" in item["reason"] or "Keyword overlap" in item["reason"] for item in payload["results"])


### PR DESCRIPTION
## Summary
- Implemented the Phase 4 MVP foundation for keyword search, semantic search, and hybrid retrieval.
- `find_related_notes(note_path)` now excludes the source note and returns clearer reasons.
- Reindex now clears stale metadata and resets the vector store to avoid polluted search results.
- Added retrieval fixtures and integration tests for `/search` and `/notes/related`.

## Linked Issue
- Closes #7

## Risk Assessment
- Keyword search is still a lightweight rule-based approach, not full FTS/BM25. It is sufficient for the current MVP, but quality can still be improved.
- Semantic search still uses deterministic local embeddings; a real embeddings provider can replace it later for better quality.

## Test Evidence
- `ruff check src tests --select F,E9,B`
- `python -m compileall src`
- Manual smoke: after reindexing retrieval fixtures, `/search` and `/notes/related` returned ranked results with reasons.

## Rollback Plan
- Revert commit `f6e5d02`, or close this PR without merging.