### PR TITLE
feat: implement Phase 5 synthesis and review flow for issue #9

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,7 @@
 - `GET /search`
 - `GET /notes/related`
 - `GET /review/pending`
+- `POST /review/generate`
 - `POST /review/{id}/approve`
 - `POST /review/{id}/reject`
 - `POST /review/{id}/apply`

--- a/src/obsidian_agent/api/routes_review.py
+++ b/src/obsidian_agent/api/routes_review.py
@@ -5,9 +5,21 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 
 from obsidian_agent.api.deps import get_api_container
+from obsidian_agent.domain.schemas import GenerateReviewRequest
 
 router = APIRouter(prefix="/review", tags=["review"])
 ContainerDep = Annotated[object, Depends(get_api_container)]
+
+
+@router.post("/generate")
+async def generate_review(
+    request: GenerateReviewRequest, container: ContainerDep
+) -> dict[str, object]:
+    related_notes = await container.retrieval_service.find_related_notes(
+        request.note_path,
+        top_k=request.top_k,
+    )
+    return await container.synthesis_workflow.run(request.note_path, related_notes)
 
 
 @router.get("/pending")

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -22,11 +22,13 @@ from obsidian_agent.services.normalize_service import NormalizeService
 from obsidian_agent.services.obsidian_service import ObsidianService
 from obsidian_agent.services.retrieval_service import RetrievalService
 from obsidian_agent.services.review_service import ReviewService
+from obsidian_agent.services.synthesis_service import SynthesisService
 from obsidian_agent.storage.db import create_session_factory
 from obsidian_agent.storage.vector_store import VectorStore
 from obsidian_agent.workflows.capture_workflow import CaptureWorkflow
 from obsidian_agent.workflows.link_workflow import LinkWorkflow
 from obsidian_agent.workflows.maintenance_workflow import MaintenanceWorkflow
+from obsidian_agent.workflows.synthesis_workflow import SynthesisWorkflow
 
 
 @dataclass
@@ -40,6 +42,8 @@ class AppContainer:
     capture_workflow: CaptureWorkflow
     retrieval_service: RetrievalService
     review_service: ReviewService
+    synthesis_service: SynthesisService
+    synthesis_workflow: SynthesisWorkflow
     indexing_service: IndexingService
     maintenance_service: MaintenanceService
     maintenance_workflow: MaintenanceWorkflow
@@ -87,6 +91,8 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         obsidian_service=obsidian_service,
         template_path=_template_path("review_note.md.tmpl"),
     )
+    synthesis_service = SynthesisService(llm_service)
+    synthesis_workflow = SynthesisWorkflow(synthesis_service, review_service)
     capture_service = CaptureService(
         session_factory=session_factory,
         obsidian_service=obsidian_service,
@@ -111,6 +117,8 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         capture_workflow=capture_workflow,
         retrieval_service=retrieval_service,
         review_service=review_service,
+        synthesis_service=synthesis_service,
+        synthesis_workflow=synthesis_workflow,
         indexing_service=indexing_service,
         maintenance_service=maintenance_service,
         maintenance_workflow=maintenance_workflow,

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -117,11 +117,19 @@ class ReviewProposal(BaseModel):
     related_links: list[str] = Field(default_factory=list)
 
 
+class GenerateReviewRequest(BaseModel):
+    note_path: str
+    top_k: int = 5
+
+
 class ReviewItemSchema(BaseModel):
     id: int | None = None
     source_note_id: int | None = None
     target_note_id: int | None = None
+    source_note_path: str | None = None
+    target_note_path: str | None = None
     proposal_type: ProposalType
+    suggested_patch: str | None = None
     proposal_path: str
     state: ReviewState
     risk_level: RiskLevel

--- a/src/obsidian_agent/services/review_service.py
+++ b/src/obsidian_agent/services/review_service.py
@@ -41,9 +41,10 @@ class ReviewService:
         return render_template(self.template_path, context)
 
     async def create_review_item(self, proposal: ReviewProposal) -> tuple[int, str]:
+        source_title = proposal.source_note_path.rsplit("/", 1)[-1].replace(".md", "")
         created = await self.obsidian_service.create_note(
             folder=self.obsidian_service.settings.review_folder,
-            title=f"Review - {compact_timestamp()}",
+            title=source_title,
             frontmatter={
                 "id": compact_timestamp(),
                 "kind": "review",
@@ -60,12 +61,20 @@ class ReviewService:
             item = repo.create(proposal, created_path)
         return item.id, created_path
 
-    async def list_pending(self) -> list[dict[str, str | int]]:
+    async def list_pending(self) -> list[dict[str, str | int | None]]:
         with self.session_factory() as session:
             repo = ReviewRepository(session)
             items = repo.list_pending()
             return [
-                {"id": item.id, "proposal_path": item.proposal_path, "state": item.state, "risk_level": item.risk_level}
+                {
+                    "id": item.id,
+                    "proposal_path": item.proposal_path,
+                    "proposal_type": item.proposal_type,
+                    "source_note_path": item.source_note_path,
+                    "target_note_path": item.target_note_path,
+                    "state": item.state,
+                    "risk_level": item.risk_level,
+                }
                 for item in items
             ]
 

--- a/src/obsidian_agent/services/synthesis_service.py
+++ b/src/obsidian_agent/services/synthesis_service.py
@@ -24,8 +24,8 @@ class SynthesisService:
         rationale = "Generated from related note analysis."
         if related_notes:
             rationale += f" Top candidate: {related_notes[0].path} ({related_notes[0].score:.2f})."
-        suggested_patch = "\n".join(f"- Link to [[{item.path}]]" for item in related_notes[:5]) or "- No links"
         proposal_type = await self.decide_action(new_note_path, related_notes)
+        suggested_patch = self._build_suggested_patch(new_note_path, related_notes, proposal_type)
         return await self.llm_service.generate_review_proposal(
             new_note_path=new_note_path,
             target_note_path=target_note_path,
@@ -33,3 +33,20 @@ class SynthesisService:
             suggested_patch=suggested_patch,
             proposal_type=proposal_type,
         )
+
+    @staticmethod
+    def _build_suggested_patch(
+        new_note_path: str,
+        related_notes: list[RelatedNoteCandidate],
+        proposal_type: ProposalType,
+    ) -> str:
+        if proposal_type == ProposalType.APPEND_CANDIDATE:
+            return f"- Link to [[{new_note_path}]]"
+        if proposal_type == ProposalType.MERGE_CANDIDATE:
+            return f"Merge candidate based on [[{new_note_path}]]"
+        if proposal_type == ProposalType.REVIEW_ONLY:
+            return "\n".join(
+                f"- Review relationship with [[{item.path}]] because {item.reason}"
+                for item in related_notes[:5]
+            ) or f"- Review [[{new_note_path}]]"
+        return f"- Created from [[{new_note_path}]]"

--- a/src/obsidian_agent/storage/repositories.py
+++ b/src/obsidian_agent/storage/repositories.py
@@ -129,6 +129,9 @@ class ReviewRepository:
     def get(self, review_id: int) -> ReviewItem | None:
         return self.session.get(ReviewItem, review_id)
 
+    def list_all(self) -> list[ReviewItem]:
+        return list(self.session.scalars(select(ReviewItem).order_by(ReviewItem.id)).all())
+
     def set_state(self, review_id: int, state: ReviewState) -> ReviewItem:
         item = self.get(review_id)
         if item is None:

--- a/tests/fixtures/review/00 Inbox/new-input.md
+++ b/tests/fixtures/review/00 Inbox/new-input.md
@@ -1,0 +1,11 @@
+---
+id: review-inbox
+kind: inbox
+status: inbox
+source_type: manual
+source_ref:
+---
+
+# New Retrieval Input
+
+This inbox note discusses retrieval workflows, note linking, and system design updates.

--- a/tests/fixtures/review/04 Evergreen/evergreen-note.md
+++ b/tests/fixtures/review/04 Evergreen/evergreen-note.md
@@ -1,0 +1,11 @@
+---
+id: review-evergreen
+kind: evergreen
+status: stable
+source_type: manual
+source_ref:
+---
+
+# Evergreen Systems Note
+
+This evergreen note describes system design, retrieval workflows, and review-based updates.

--- a/tests/integration/test_review_flow.py
+++ b/tests/integration/test_review_flow.py
@@ -1,0 +1,107 @@
+import asyncio
+from pathlib import Path
+from shutil import copytree
+
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import build_container, create_app
+from obsidian_agent.domain.enums import ProposalType, RiskLevel, ReviewState
+from obsidian_agent.domain.schemas import ReviewProposal
+def _build_review_client(tmp_path: Path):
+    fixture_root = Path("tests/fixtures/review")
+    vault_root = tmp_path / "vault"
+    copytree(fixture_root, vault_root)
+    settings_module = __import__("obsidian_agent.config", fromlist=["Settings"])
+    settings = settings_module.Settings(
+        obsidian_mode="filesystem",
+        vault_root=vault_root,
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+    )
+    app = create_app()
+    container = build_container(settings)
+    app.state.container = container
+    asyncio.run(container.indexing_service.reindex_all())
+    client = TestClient(app)
+    return client, container, settings
+
+
+def test_generate_review_creates_pending_item(tmp_path: Path) -> None:
+    client, _, _ = _build_review_client(tmp_path)
+    response = client.post("/review/generate", json={"note_path": "00 Inbox/new-input.md", "top_k": 3})
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["review_id"] > 0
+    assert payload["proposal"]["proposal_type"] in {
+        "append_candidate",
+        "merge_candidate",
+        "review_only",
+        "new_note",
+    }
+
+
+def test_approve_and_apply_append_review_updates_target_note(tmp_path: Path) -> None:
+    _, container, settings = _build_review_client(tmp_path)
+    proposal = ReviewProposal(
+        proposal_type=ProposalType.APPEND_CANDIDATE,
+        risk_level=RiskLevel.MEDIUM,
+        title="Append Related Notes",
+        source_note_path="00 Inbox/new-input.md",
+        target_note_path="04 Evergreen/evergreen-note.md",
+        rationale="Related topic overlap.",
+        suggested_patch="- Link to [[00 Inbox/new-input.md]]",
+        related_links=["00 Inbox/new-input.md"],
+    )
+    review_id, _ = asyncio.run(container.review_service.create_review_item(proposal))
+    asyncio.run(container.review_service.approve(review_id))
+    asyncio.run(container.review_service.apply_approved_review(review_id))
+    updated = (settings.vault_root / "04 Evergreen/evergreen-note.md").read_text(encoding="utf-8")
+    assert "Related Notes" in updated
+    assert "[[00 Inbox/new-input.md]]" in updated
+    assert "[[04 Evergreen/evergreen-note.md]]" not in updated
+
+
+def test_high_risk_review_cannot_be_applied(tmp_path: Path) -> None:
+    _, container, _ = _build_review_client(tmp_path)
+    proposal = ReviewProposal(
+        proposal_type=ProposalType.MERGE_CANDIDATE,
+        risk_level=RiskLevel.HIGH,
+        title="High Risk Merge",
+        source_note_path="00 Inbox/new-input.md",
+        target_note_path="04 Evergreen/evergreen-note.md",
+        rationale="High risk merge candidate.",
+        suggested_patch="Merge content",
+        related_links=[],
+    )
+    review_id, _ = asyncio.run(container.review_service.create_review_item(proposal))
+    asyncio.run(container.review_service.approve(review_id))
+    try:
+        asyncio.run(container.review_service.apply_approved_review(review_id))
+    except ValueError as exc:
+        assert "cannot be auto-applied" in str(exc)
+    else:
+        raise AssertionError("Expected high risk review application to fail")
+
+
+def test_reject_review_keeps_state_rejected(tmp_path: Path) -> None:
+    _, container, _ = _build_review_client(tmp_path)
+    proposal = ReviewProposal(
+        proposal_type=ProposalType.APPEND_CANDIDATE,
+        risk_level=RiskLevel.MEDIUM,
+        title="Reject Review",
+        source_note_path="00 Inbox/new-input.md",
+        target_note_path="04 Evergreen/evergreen-note.md",
+        rationale="Test reject flow.",
+        suggested_patch="- Link",
+        related_links=[],
+    )
+    review_id, _ = asyncio.run(container.review_service.create_review_item(proposal))
+    asyncio.run(container.review_service.reject(review_id))
+    with container.session_factory() as session:
+        repo = __import__(
+            "obsidian_agent.storage.repositories",
+            fromlist=["ReviewRepository"],
+        ).ReviewRepository(session)
+        item = repo.get(review_id)
+        assert item is not None
+        assert item.state == ReviewState.REJECTED.value


### PR DESCRIPTION
## Summary
- Added `POST /review/generate` to create Review proposals from a note path and its related notes.
- Connected retrieval, synthesis, review item creation, approval, rejection, and apply into a single executable flow.
- Extended the pending-review listing with proposal type and source/target note paths.
- Fixed `append_candidate` apply logic so the source note link is appended to the target note instead of self-linking the target note.
- Added review fixtures and integration coverage for generate, approve, reject, apply, and high-risk auto-apply blocking.

## Linked Issue
- Closes #9

## Risk Assessment
- Auto-apply is intentionally implemented only for `append_candidate` at this stage; `merge_candidate` and `review_only` still stop at the proposal layer.
- Proposal text is still generated primarily from rules and retrieval context; richer LLM patch generation can be added later.

## Test Evidence
- `ruff check src tests --select F,E9,B`
- `python -m compileall src`
- Manual smoke: `/review/generate -> /review/{id}/approve -> /review/{id}/apply` completed, and the target note correctly received `[[00 Inbox/new-input.md]]`.
- High-risk proposals remain blocked from automatic apply.

## Rollback Plan
- Revert commit `14314c2`, or close this PR without merging.