### PR TITLE
feat: implement frontend control panel for issue #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ python scripts/seed_demo_data.py
 uvicorn obsidian_agent.app:create_app --factory --reload
 ```
 
+Or on Windows, start the local dashboard with one script:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/start_dashboard.ps1
+```
+
+Then open `http://127.0.0.1:8000/`.
+
 5. Run static checks.
 
 ```bash
@@ -70,5 +78,7 @@ python -m compileall src scripts
 - Vault writes go through `ObsidianService` only.
 - `DRY_RUN=true` returns action previews for write paths instead of mutating the vault.
 - Prompt assets live under `src/obsidian_agent/prompts/` and are tracked by `manifest.json`.
+- The built-in control panel is served from `/` and `/ui`.
+- The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, search notes, inspect review items, and run maintenance jobs.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -23,6 +23,14 @@ Set at least:
 uvicorn obsidian_agent.app:create_app --factory --reload
 ```
 
+Or on Windows:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/start_dashboard.ps1
+```
+
+Then open `http://127.0.0.1:8000/` to use the built-in control panel.
+
 ## 3. Build Local Indexes
 
 ```bash

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,3 +5,4 @@ Automation and developer helpers live here.
 - `seed_demo_data.py`: populate `data/demo_vault` with realistic C-language sample notes
 - `reindex_all.py`: rebuild local metadata and vector indexes
 - `create_or_update_pr.py`: create or update GitHub PR bodies with explicit UTF-8 handling
+- `start_dashboard.ps1`: install dependencies into `.venv` if needed and launch the local web control panel

--- a/scripts/seed_demo_data.py
+++ b/scripts/seed_demo_data.py
@@ -2,76 +2,11 @@
 
 from pathlib import Path
 
-from obsidian_agent.utils.frontmatter import dump_frontmatter
+from obsidian_agent.utils.demo_data import seed_demo_vault
 
 
 def main() -> None:
-    vault = Path("data/demo_vault")
-    (vault / "00 Inbox").mkdir(parents=True, exist_ok=True)
-    (vault / "01 Daily").mkdir(parents=True, exist_ok=True)
-    (vault / "02 Literature").mkdir(parents=True, exist_ok=True)
-    (vault / "03 Projects").mkdir(parents=True, exist_ok=True)
-    (vault / "04 Evergreen").mkdir(parents=True, exist_ok=True)
-    (vault / "05 Entities").mkdir(parents=True, exist_ok=True)
-    (vault / "90 Review").mkdir(parents=True, exist_ok=True)
-
-    notes = {
-        "04 Evergreen/c-memory-model.md": (
-            {
-                "id": "seed-1",
-                "kind": "evergreen",
-                "status": "stable",
-                "source_type": "manual",
-                "source_ref": ""
-            },
-            "# C Memory Model\n\nC programs rely on explicit ownership, pointer validity, and careful lifetime rules.\n\n## Related Notes\n- [[03 Projects/c-build-pipeline.md]]\n- [[05 Entities/stdio.md]]\n",
-        ),
-        "03 Projects/c-build-pipeline.md": (
-            {
-                "id": "seed-2",
-                "kind": "project",
-                "status": "active",
-                "source_type": "manual",
-                "source_ref": ""
-            },
-            "# C Build Pipeline\n\nThe demo project compiles with `clang`, runs unit tests, and publishes warnings as CI annotations.\n",
-        ),
-        "02 Literature/c-struct-layout.md": (
-            {
-                "id": "seed-3",
-                "kind": "literature",
-                "status": "reference",
-                "source_type": "url",
-                "source_ref": "https://example.com/c-struct-layout"
-            },
-            "# Struct Layout Notes\n\nStructure padding affects ABI stability, binary serialization, and memory locality.\n",
-        ),
-        "05 Entities/stdio.md": (
-            {
-                "id": "seed-4",
-                "kind": "entity",
-                "status": "stable",
-                "source_type": "manual",
-                "source_ref": ""
-            },
-            "# stdio\n\n`stdio.h` defines buffered IO interfaces such as `printf`, `fprintf`, and `fopen`.\n",
-        ),
-        "00 Inbox/new-capture.md": (
-            {
-                "id": "seed-5",
-                "kind": "inbox",
-                "status": "inbox",
-                "source_type": "text",
-                "source_ref": "seed"
-            },
-            "# New Capture\n\nA fresh capture about pointer aliasing and ownership in C.\n",
-        ),
-    }
-
-    for relative_path, (frontmatter, body) in notes.items():
-        target = vault / relative_path
-        target.parent.mkdir(parents=True, exist_ok=True)
-        target.write_text(dump_frontmatter(frontmatter) + f"\n\n{body}", encoding="utf-8")
+    seed_demo_vault(Path("data/demo_vault"))
 
 
 if __name__ == "__main__":

--- a/scripts/start_dashboard.ps1
+++ b/scripts/start_dashboard.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+Set-Location $root
+
+if (-not (Test-Path ".venv")) {
+  python -m venv .venv
+}
+
+& .\.venv\Scripts\python.exe -m pip install -e .[dev]
+& .\.venv\Scripts\python.exe -m uvicorn obsidian_agent.app:create_app --factory --reload

--- a/src/obsidian_agent/api/routes_ui.py
+++ b/src/obsidian_agent/api/routes_ui.py
@@ -1,0 +1,178 @@
+"""Operator UI and runtime management routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, Request
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+
+from obsidian_agent.app import build_container
+from obsidian_agent.config import Settings
+from obsidian_agent.utils.demo_data import seed_demo_vault
+from obsidian_agent.utils.envfile import read_env_file, write_env_file
+
+router = APIRouter(tags=["ui"])
+
+
+class UiConfigPayload(BaseModel):
+    llm_provider: str = "deepseek"
+    deepseek_api_key: str = ""
+    deepseek_base_url: str = "https://api.deepseek.com"
+    deepseek_model: str = "deepseek-chat"
+    openai_api_key: str = ""
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_model: str = "gpt-4.1-mini"
+    obsidian_mode: str = "auto"
+    obsidian_api_url: str = ""
+    obsidian_api_key: str = ""
+    obsidian_verify_ssl: bool = False
+    vault_root: str = "./data/demo_vault"
+    sqlite_path: str = "./data/processed/obsidian_agent.db"
+    vector_store_path: str = "./data/processed/vector_index.json"
+    log_level: str = "INFO"
+    dry_run: bool = False
+    http_timeout_seconds: float = 30.0
+    http_retry_attempts: int = 3
+    http_retry_backoff_seconds: float = 0.5
+    review_folder: str = "90 Review"
+    inbox_folder: str = "00 Inbox"
+
+
+class WeeklyDigestRunRequest(BaseModel):
+    week_key: str = Field(min_length=4)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _ui_root() -> Path:
+    return Path(__file__).resolve().parents[1] / "ui"
+
+
+def _env_path(request: Request) -> Path:
+    return getattr(request.app.state, "ui_env_path", _repo_root() / ".env")
+
+
+def _settings_to_payload(request: Request) -> UiConfigPayload:
+    settings = request.app.state.container.settings
+    return UiConfigPayload(
+        llm_provider=settings.llm_provider,
+        deepseek_api_key=settings.deepseek_api_key or "",
+        deepseek_base_url=settings.deepseek_base_url,
+        deepseek_model=settings.deepseek_model,
+        openai_api_key=settings.openai_api_key or "",
+        openai_base_url=settings.openai_base_url,
+        openai_model=settings.openai_model,
+        obsidian_mode=settings.obsidian_mode,
+        obsidian_api_url=settings.obsidian_api_url or "",
+        obsidian_api_key=settings.obsidian_api_key or "",
+        obsidian_verify_ssl=settings.obsidian_verify_ssl,
+        vault_root=str(settings.vault_root),
+        sqlite_path=str(settings.sqlite_path),
+        vector_store_path=str(settings.vector_store_path),
+        log_level=settings.log_level,
+        dry_run=settings.dry_run,
+        http_timeout_seconds=settings.http_timeout_seconds,
+        http_retry_attempts=settings.http_retry_attempts,
+        http_retry_backoff_seconds=settings.http_retry_backoff_seconds,
+        review_folder=settings.review_folder,
+        inbox_folder=settings.inbox_folder,
+    )
+
+
+def _load_settings_from_env(request: Request) -> Settings:
+    return Settings(_env_file=_env_path(request), _env_file_encoding="utf-8")
+
+
+@router.get("/")
+async def dashboard() -> FileResponse:
+    return FileResponse(_ui_root() / "index.html")
+
+
+@router.get("/ui")
+async def dashboard_alias() -> FileResponse:
+    return FileResponse(_ui_root() / "index.html")
+
+
+@router.get("/ui/api/runtime")
+async def runtime_state(request: Request) -> dict[str, object]:
+    container = request.app.state.container
+    settings = container.settings
+    return {
+        "app_name": settings.app_name,
+        "health": "ok",
+        "env_path": str(_env_path(request)),
+        "settings": _settings_to_payload(request).model_dump(mode="json"),
+    }
+
+
+@router.get("/ui/api/config")
+async def load_config(request: Request) -> dict[str, object]:
+    env_values = read_env_file(_env_path(request))
+    return {
+        "env_path": str(_env_path(request)),
+        "settings": _settings_to_payload(request).model_dump(mode="json"),
+        "raw_env": env_values,
+    }
+
+
+@router.put("/ui/api/config")
+async def save_config(payload: UiConfigPayload, request: Request) -> dict[str, object]:
+    env_values = {
+        "LLM_PROVIDER": payload.llm_provider,
+        "DEEPSEEK_API_KEY": payload.deepseek_api_key,
+        "DEEPSEEK_BASE_URL": payload.deepseek_base_url,
+        "DEEPSEEK_MODEL": payload.deepseek_model,
+        "OPENAI_API_KEY": payload.openai_api_key,
+        "OPENAI_BASE_URL": payload.openai_base_url,
+        "OPENAI_MODEL": payload.openai_model,
+        "OBSIDIAN_MODE": payload.obsidian_mode,
+        "OBSIDIAN_API_URL": payload.obsidian_api_url,
+        "OBSIDIAN_API_KEY": payload.obsidian_api_key,
+        "OBSIDIAN_VERIFY_SSL": str(payload.obsidian_verify_ssl).lower(),
+        "VAULT_ROOT": payload.vault_root,
+        "SQLITE_PATH": payload.sqlite_path,
+        "VECTOR_STORE_PATH": payload.vector_store_path,
+        "LOG_LEVEL": payload.log_level,
+        "DRY_RUN": str(payload.dry_run).lower(),
+        "HTTP_TIMEOUT_SECONDS": str(payload.http_timeout_seconds),
+        "HTTP_RETRY_ATTEMPTS": str(payload.http_retry_attempts),
+        "HTTP_RETRY_BACKOFF_SECONDS": str(payload.http_retry_backoff_seconds),
+        "REVIEW_FOLDER": payload.review_folder,
+        "INBOX_FOLDER": payload.inbox_folder,
+    }
+    write_env_file(_env_path(request), env_values)
+    request.app.state.container = build_container(_load_settings_from_env(request))
+    return {"saved": True, "settings": _settings_to_payload(request).model_dump(mode="json")}
+
+
+@router.post("/ui/api/reload")
+async def reload_runtime(request: Request) -> dict[str, object]:
+    request.app.state.container = build_container(_load_settings_from_env(request))
+    return {"reloaded": True, "settings": _settings_to_payload(request).model_dump(mode="json")}
+
+
+@router.post("/ui/api/seed-demo")
+async def seed_demo(request: Request) -> dict[str, object]:
+    settings = request.app.state.container.settings
+    paths = seed_demo_vault(settings.vault_root)
+    return {"seeded": True, "count": len(paths), "paths": sorted(paths)}
+
+
+@router.post("/ui/api/reindex")
+async def reindex_from_ui(request: Request) -> dict[str, object]:
+    paths = await request.app.state.container.indexing_service.reindex_all()
+    return {"count": len(paths), "paths": paths}
+
+
+@router.post("/ui/api/weekly-digest")
+async def weekly_digest_from_ui(
+    payload: WeeklyDigestRunRequest, request: Request
+) -> dict[str, object]:
+    result = await request.app.state.container.maintenance_workflow.weekly_digest(payload.week_key)
+    if hasattr(result, "model_dump"):
+        return {"status": "dry_run", "action_preview": result.model_dump(mode="json")}
+    return {"status": "created", "path": result}

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from fastapi import FastAPI, Request
+from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import sessionmaker
 
 from obsidian_agent.config import Settings, get_settings
@@ -52,6 +53,10 @@ class AppContainer:
 
 def _template_path(name: str) -> Path:
     return Path(__file__).resolve().parent / "prompts" / "tasks" / name
+
+
+def _ui_path(name: str) -> Path:
+    return Path(__file__).resolve().parent / "ui" / name
 
 
 def build_container(settings: Settings | None = None) -> AppContainer:
@@ -148,10 +153,13 @@ def create_app() -> FastAPI:
     from obsidian_agent.api.routes_maintenance import router as maintenance_router
     from obsidian_agent.api.routes_review import router as review_router
     from obsidian_agent.api.routes_search import router as search_router
+    from obsidian_agent.api.routes_ui import router as ui_router
 
     app = FastAPI(title="LLM2Obsidian")
     app.middleware("http")(trace_middleware)
     app.state.container = build_container()
+    app.mount("/ui/assets", StaticFiles(directory=_ui_path("")), name="ui-assets")
+    app.include_router(ui_router)
     app.include_router(capture_router)
     app.include_router(search_router)
     app.include_router(review_router)

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -1,0 +1,176 @@
+const consoleOutput = document.getElementById("consoleOutput");
+const configForm = document.getElementById("configForm");
+
+function logResult(label, payload) {
+  const rendered = typeof payload === "string" ? payload : JSON.stringify(payload, null, 2);
+  consoleOutput.textContent = `[${new Date().toLocaleTimeString()}] ${label}\n${rendered}\n\n${consoleOutput.textContent}`;
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    ...options,
+  });
+  const contentType = response.headers.get("content-type") || "";
+  const payload = contentType.includes("application/json") ? await response.json() : await response.text();
+  if (!response.ok) {
+    throw new Error(typeof payload === "string" ? payload : JSON.stringify(payload));
+  }
+  return payload;
+}
+
+function setFormValues(values) {
+  for (const [key, value] of Object.entries(values)) {
+    const input = configForm.elements.namedItem(key);
+    if (!input) continue;
+    if (input.type === "checkbox") {
+      input.checked = Boolean(value);
+    } else {
+      input.value = value ?? "";
+    }
+  }
+}
+
+function getFormValues() {
+  const data = new FormData(configForm);
+  return {
+    llm_provider: data.get("llm_provider") || "deepseek",
+    deepseek_api_key: data.get("deepseek_api_key") || "",
+    deepseek_base_url: data.get("deepseek_base_url") || "",
+    deepseek_model: data.get("deepseek_model") || "",
+    openai_api_key: data.get("openai_api_key") || "",
+    openai_base_url: data.get("openai_base_url") || "",
+    openai_model: data.get("openai_model") || "",
+    obsidian_mode: data.get("obsidian_mode") || "auto",
+    obsidian_api_url: data.get("obsidian_api_url") || "",
+    obsidian_api_key: data.get("obsidian_api_key") || "",
+    obsidian_verify_ssl: configForm.elements.namedItem("obsidian_verify_ssl").checked,
+    vault_root: data.get("vault_root") || "",
+    sqlite_path: data.get("sqlite_path") || "",
+    vector_store_path: data.get("vector_store_path") || "",
+    log_level: data.get("log_level") || "INFO",
+    dry_run: configForm.elements.namedItem("dry_run").checked,
+    http_timeout_seconds: Number(data.get("http_timeout_seconds") || 30),
+    http_retry_attempts: Number(data.get("http_retry_attempts") || 3),
+    http_retry_backoff_seconds: Number(data.get("http_retry_backoff_seconds") || 0.5),
+    review_folder: data.get("review_folder") || "90 Review",
+    inbox_folder: data.get("inbox_folder") || "00 Inbox",
+  };
+}
+
+function renderCards(target, items, formatter) {
+  target.innerHTML = "";
+  if (!items.length) {
+    target.innerHTML = '<div class="result-card"><strong>No items</strong><small>The result set is empty.</small></div>';
+    return;
+  }
+  for (const item of items) {
+    const card = document.createElement("article");
+    card.className = "result-card";
+    card.innerHTML = formatter(item);
+    target.appendChild(card);
+  }
+}
+
+async function loadRuntime() {
+  const runtime = await api("/ui/api/runtime");
+  document.getElementById("healthBadge").textContent = runtime.health;
+  document.getElementById("envPath").textContent = runtime.env_path;
+  setFormValues(runtime.settings);
+  logResult("Runtime loaded", runtime);
+}
+
+async function loadReviews() {
+  const payload = await api("/review/pending");
+  renderCards(document.getElementById("reviewResults"), payload.items, (item) => `
+    <strong>#${item.id} · ${item.proposal_type}</strong>
+    <div>${item.source_note_path || ""}</div>
+    <small>${item.target_note_path || "No target note"} · ${item.risk_level}</small>
+  `);
+  logResult("Review queue refreshed", payload);
+}
+
+async function runMaintenance(target) {
+  const payload = await api(`/maintenance/${target}`);
+  renderCards(document.getElementById("maintenanceResults"), payload.items, (item) => `
+    <strong>${item.path}</strong>
+    <div>${item.reason}</div>
+    <small>score: ${item.score}</small>
+  `);
+  logResult(`Maintenance ${target}`, payload);
+}
+
+document.getElementById("saveConfig").addEventListener("click", async () => {
+  const payload = await api("/ui/api/config", {
+    method: "PUT",
+    body: JSON.stringify(getFormValues()),
+  });
+  logResult("Config saved", payload);
+  setFormValues(payload.settings);
+});
+
+document.getElementById("reloadRuntime").addEventListener("click", async () => {
+  const payload = await api("/ui/api/reload", { method: "POST" });
+  logResult("Runtime reloaded", payload);
+  setFormValues(payload.settings);
+});
+
+document.getElementById("seedDemo").addEventListener("click", async () => {
+  const payload = await api("/ui/api/seed-demo", { method: "POST" });
+  logResult("Demo vault seeded", payload);
+});
+
+document.getElementById("reindex").addEventListener("click", async () => {
+  const payload = await api("/ui/api/reindex", { method: "POST" });
+  logResult("Vault reindexed", payload);
+});
+
+document.getElementById("runDigest").addEventListener("click", async () => {
+  const payload = await api("/ui/api/weekly-digest", {
+    method: "POST",
+    body: JSON.stringify({ week_key: document.getElementById("weekKey").value }),
+  });
+  logResult("Weekly digest", payload);
+});
+
+document.getElementById("captureSubmit").addEventListener("click", async () => {
+  const payload = await api("/capture/text", {
+    method: "POST",
+    body: JSON.stringify({
+      title: document.getElementById("captureTitle").value,
+      text: document.getElementById("captureText").value,
+      source_ref: "ui",
+    }),
+  });
+  logResult("Capture complete", payload);
+});
+
+document.getElementById("searchSubmit").addEventListener("click", async () => {
+  const query = document.getElementById("searchQuery").value;
+  const payload = await api(`/search?q=${encodeURIComponent(query)}`);
+  renderCards(document.getElementById("searchResults"), payload.results, (item) => `
+    <strong>${item.path}</strong>
+    <div>${item.reason}</div>
+    <small>score: ${item.score}</small>
+  `);
+  logResult("Search complete", payload);
+});
+
+document.getElementById("refreshReviews").addEventListener("click", loadReviews);
+document.getElementById("refreshMaintenance").addEventListener("click", async () => {
+  await runMaintenance("duplicates");
+});
+
+for (const button of document.querySelectorAll(".maintenance-trigger")) {
+  button.addEventListener("click", async () => {
+    await runMaintenance(button.dataset.target);
+  });
+}
+
+document.getElementById("clearConsole").addEventListener("click", () => {
+  consoleOutput.textContent = "Console cleared.";
+});
+
+loadRuntime()
+  .then(loadReviews)
+  .catch((error) => logResult("Startup error", error.message));

--- a/src/obsidian_agent/ui/index.html
+++ b/src/obsidian_agent/ui/index.html
@@ -1,0 +1,127 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>LLM2Obsidian Control Panel</title>
+    <link rel="stylesheet" href="/ui/assets/styles.css">
+  </head>
+  <body>
+    <div class="page-shell">
+      <header class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">LLM2Obsidian</p>
+          <h1>Control Panel</h1>
+          <p class="lede">
+            Configure providers, connect Obsidian, and run the core workflows without touching
+            curl.
+          </p>
+        </div>
+        <div class="status-card">
+          <span id="healthBadge" class="badge">checking</span>
+          <p id="envPath" class="env-path">Loading runtime...</p>
+          <button id="reloadRuntime" class="secondary-button">Reload Runtime</button>
+        </div>
+      </header>
+
+      <main class="dashboard-grid">
+        <section class="panel panel-wide">
+          <div class="panel-head">
+            <h2>Runtime Config</h2>
+            <button id="saveConfig" class="primary-button">Save Config</button>
+          </div>
+          <form id="configForm" class="config-grid">
+            <label><span>LLM Provider</span><input name="llm_provider" value="deepseek"></label>
+            <label><span>Obsidian Mode</span><input name="obsidian_mode" value="auto"></label>
+            <label><span>Vault Root</span><input name="vault_root"></label>
+            <label><span>SQLite Path</span><input name="sqlite_path"></label>
+            <label><span>Vector Store Path</span><input name="vector_store_path"></label>
+            <label><span>Obsidian API URL</span><input name="obsidian_api_url"></label>
+            <label><span>Obsidian API Key</span><input name="obsidian_api_key" type="password"></label>
+            <label><span>DeepSeek API Key</span><input name="deepseek_api_key" type="password"></label>
+            <label><span>DeepSeek Base URL</span><input name="deepseek_base_url"></label>
+            <label><span>DeepSeek Model</span><input name="deepseek_model"></label>
+            <label><span>OpenAI API Key</span><input name="openai_api_key" type="password"></label>
+            <label><span>OpenAI Base URL</span><input name="openai_base_url"></label>
+            <label><span>OpenAI Model</span><input name="openai_model"></label>
+            <label><span>Log Level</span><input name="log_level"></label>
+            <label><span>Review Folder</span><input name="review_folder"></label>
+            <label><span>Inbox Folder</span><input name="inbox_folder"></label>
+            <label><span>HTTP Timeout</span><input name="http_timeout_seconds" type="number" step="0.5"></label>
+            <label><span>Retry Attempts</span><input name="http_retry_attempts" type="number" step="1"></label>
+            <label><span>Retry Backoff</span><input name="http_retry_backoff_seconds" type="number" step="0.1"></label>
+            <label class="toggle"><span>Verify SSL</span><input name="obsidian_verify_ssl" type="checkbox"></label>
+            <label class="toggle"><span>Dry Run</span><input name="dry_run" type="checkbox"></label>
+          </form>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Quick Actions</h2>
+          </div>
+          <div class="stack">
+            <button id="seedDemo" class="primary-button">Seed Demo Vault</button>
+            <button id="reindex" class="primary-button">Reindex Vault</button>
+            <div class="inline-form">
+              <input id="weekKey" value="2026-W11" aria-label="Week key">
+              <button id="runDigest" class="secondary-button">Weekly Digest</button>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Capture Text</h2>
+          </div>
+          <div class="stack">
+            <input id="captureTitle" placeholder="Title">
+            <textarea id="captureText" rows="8" placeholder="Paste a note, article excerpt, or idea..."></textarea>
+            <button id="captureSubmit" class="primary-button">Capture to Inbox</button>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Search</h2>
+          </div>
+          <div class="stack">
+            <input id="searchQuery" placeholder="Search notes">
+            <button id="searchSubmit" class="secondary-button">Run Search</button>
+            <div id="searchResults" class="result-list"></div>
+          </div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Review Queue</h2>
+            <button id="refreshReviews" class="ghost-button">Refresh</button>
+          </div>
+          <div id="reviewResults" class="result-list"></div>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Maintenance</h2>
+            <button id="refreshMaintenance" class="ghost-button">Refresh</button>
+          </div>
+          <div class="stack maintenance-buttons">
+            <button data-target="duplicates" class="ghost-button maintenance-trigger">Duplicates</button>
+            <button data-target="orphans" class="ghost-button maintenance-trigger">Orphans</button>
+            <button data-target="metadata-issues" class="ghost-button maintenance-trigger">Metadata Issues</button>
+          </div>
+          <div id="maintenanceResults" class="result-list"></div>
+        </section>
+
+        <section class="panel panel-wide console-panel">
+          <div class="panel-head">
+            <h2>Console</h2>
+            <button id="clearConsole" class="ghost-button">Clear</button>
+          </div>
+          <pre id="consoleOutput" class="console-output">Waiting for action...</pre>
+        </section>
+      </main>
+    </div>
+
+    <script src="/ui/assets/app.js" defer></script>
+  </body>
+  </html>

--- a/src/obsidian_agent/ui/styles.css
+++ b/src/obsidian_agent/ui/styles.css
@@ -1,0 +1,257 @@
+:root {
+  --bg: #f4efe4;
+  --paper: rgba(255, 250, 240, 0.86);
+  --ink: #1f1a16;
+  --muted: #6d5b4b;
+  --line: rgba(74, 52, 35, 0.18);
+  --accent: #b5492f;
+  --accent-2: #215f5c;
+  --shadow: 0 18px 40px rgba(65, 42, 26, 0.14);
+  --radius: 22px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at top left, rgba(181, 73, 47, 0.16), transparent 28%),
+    radial-gradient(circle at top right, rgba(33, 95, 92, 0.18), transparent 24%),
+    linear-gradient(180deg, #f7f1e6 0%, #efe3d0 100%);
+  font-family: "Segoe UI Variable Text", "Bahnschrift", "Trebuchet MS", sans-serif;
+}
+
+.page-shell {
+  max-width: 1320px;
+  margin: 0 auto;
+  padding: 32px 20px 40px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: 1.8fr 1fr;
+  gap: 20px;
+  margin-bottom: 20px;
+}
+
+.hero-copy,
+.status-card,
+.panel {
+  background: var(--paper);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.hero-copy {
+  padding: 28px;
+}
+
+.status-card {
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--muted);
+  font-size: 0.76rem;
+}
+
+h1,
+h2 {
+  margin: 0;
+  font-family: Georgia, "Times New Roman", serif;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 4vw, 4.6rem);
+  line-height: 0.95;
+}
+
+.lede {
+  margin: 14px 0 0;
+  max-width: 54ch;
+  color: var(--muted);
+  font-size: 1rem;
+}
+
+.env-path {
+  margin: 14px 0;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 20px;
+}
+
+.panel {
+  padding: 22px;
+}
+
+.panel-wide {
+  grid-column: 1 / -1;
+}
+
+.panel-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.config-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 0.88rem;
+  color: var(--muted);
+}
+
+label span {
+  font-weight: 600;
+}
+
+input,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  padding: 12px 14px;
+  color: var(--ink);
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.toggle {
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+button {
+  border: 0;
+  border-radius: 999px;
+  padding: 12px 18px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 160ms ease, opacity 160ms ease, background 160ms ease;
+}
+
+button:hover {
+  transform: translateY(-1px);
+}
+
+.primary-button {
+  background: var(--accent);
+  color: #fff8f2;
+}
+
+.secondary-button {
+  background: var(--accent-2);
+  color: #effffd;
+}
+
+.ghost-button {
+  background: rgba(33, 95, 92, 0.08);
+  color: var(--accent-2);
+}
+
+.badge {
+  align-self: flex-start;
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(33, 95, 92, 0.12);
+  color: var(--accent-2);
+  text-transform: uppercase;
+  font-size: 0.76rem;
+  letter-spacing: 0.08em;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.inline-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+}
+
+.result-list {
+  display: grid;
+  gap: 10px;
+}
+
+.result-card {
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.68);
+}
+
+.result-card strong {
+  display: block;
+  margin-bottom: 6px;
+}
+
+.result-card small {
+  color: var(--muted);
+}
+
+.maintenance-buttons {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.console-panel {
+  overflow: hidden;
+}
+
+.console-output {
+  margin: 0;
+  min-height: 220px;
+  border-radius: 18px;
+  padding: 18px;
+  background: #1d1c1a;
+  color: #e8f4dd;
+  overflow: auto;
+  font-family: Consolas, "Liberation Mono", monospace;
+  font-size: 0.92rem;
+}
+
+@media (max-width: 980px) {
+  .hero,
+  .dashboard-grid,
+  .config-grid,
+  .maintenance-buttons {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/obsidian_agent/utils/demo_data.py
+++ b/src/obsidian_agent/utils/demo_data.py
@@ -1,0 +1,80 @@
+"""Seed realistic demo notes into a target vault."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from obsidian_agent.utils.frontmatter import dump_frontmatter
+
+
+def seed_demo_vault(vault: Path) -> list[str]:
+    """Create or update a small C-language knowledge base for demos."""
+
+    (vault / "00 Inbox").mkdir(parents=True, exist_ok=True)
+    (vault / "01 Daily").mkdir(parents=True, exist_ok=True)
+    (vault / "02 Literature").mkdir(parents=True, exist_ok=True)
+    (vault / "03 Projects").mkdir(parents=True, exist_ok=True)
+    (vault / "04 Evergreen").mkdir(parents=True, exist_ok=True)
+    (vault / "05 Entities").mkdir(parents=True, exist_ok=True)
+    (vault / "90 Review").mkdir(parents=True, exist_ok=True)
+
+    notes = {
+        "04 Evergreen/c-memory-model.md": (
+            {
+                "id": "seed-1",
+                "kind": "evergreen",
+                "status": "stable",
+                "source_type": "manual",
+                "source_ref": "",
+            },
+            "# C Memory Model\n\nC programs rely on explicit ownership, pointer validity, and careful lifetime rules.\n\n## Related Notes\n- [[03 Projects/c-build-pipeline.md]]\n- [[05 Entities/stdio.md]]\n",
+        ),
+        "03 Projects/c-build-pipeline.md": (
+            {
+                "id": "seed-2",
+                "kind": "project",
+                "status": "active",
+                "source_type": "manual",
+                "source_ref": "",
+            },
+            "# C Build Pipeline\n\nThe demo project compiles with `clang`, runs unit tests, and publishes warnings as CI annotations.\n",
+        ),
+        "02 Literature/c-struct-layout.md": (
+            {
+                "id": "seed-3",
+                "kind": "literature",
+                "status": "reference",
+                "source_type": "url",
+                "source_ref": "https://example.com/c-struct-layout",
+            },
+            "# Struct Layout Notes\n\nStructure padding affects ABI stability, binary serialization, and memory locality.\n",
+        ),
+        "05 Entities/stdio.md": (
+            {
+                "id": "seed-4",
+                "kind": "entity",
+                "status": "stable",
+                "source_type": "manual",
+                "source_ref": "",
+            },
+            "# stdio\n\n`stdio.h` defines buffered IO interfaces such as `printf`, `fprintf`, and `fopen`.\n",
+        ),
+        "00 Inbox/new-capture.md": (
+            {
+                "id": "seed-5",
+                "kind": "inbox",
+                "status": "inbox",
+                "source_type": "text",
+                "source_ref": "seed",
+            },
+            "# New Capture\n\nA fresh capture about pointer aliasing and ownership in C.\n",
+        ),
+    }
+
+    paths: list[str] = []
+    for relative_path, (frontmatter, body) in notes.items():
+        target = vault / relative_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(dump_frontmatter(frontmatter) + f"\n\n{body}", encoding="utf-8")
+        paths.append(relative_path)
+    return sorted(paths)

--- a/src/obsidian_agent/utils/envfile.py
+++ b/src/obsidian_agent/utils/envfile.py
@@ -1,0 +1,61 @@
+"""Helpers for reading and writing local .env files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+KNOWN_ENV_KEYS = [
+    "LLM_PROVIDER",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+    "DEEPSEEK_API_KEY",
+    "DEEPSEEK_BASE_URL",
+    "DEEPSEEK_MODEL",
+    "OBSIDIAN_MODE",
+    "OBSIDIAN_API_URL",
+    "OBSIDIAN_API_KEY",
+    "OBSIDIAN_VERIFY_SSL",
+    "VAULT_ROOT",
+    "SQLITE_PATH",
+    "VECTOR_STORE_PATH",
+    "LOG_LEVEL",
+    "DRY_RUN",
+    "HTTP_TIMEOUT_SECONDS",
+    "HTTP_RETRY_ATTEMPTS",
+    "HTTP_RETRY_BACKOFF_SECONDS",
+    "REVIEW_FOLDER",
+    "INBOX_FOLDER",
+]
+
+
+def read_env_file(path: Path) -> dict[str, str]:
+    """Read a simple KEY=VALUE env file."""
+
+    if not path.exists():
+        return {}
+
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip()
+    return values
+
+
+def write_env_file(path: Path, values: dict[str, str]) -> None:
+    """Write a normalized env file with a stable key order."""
+
+    lines: list[str] = []
+    seen: set[str] = set()
+    for key in KNOWN_ENV_KEYS:
+        if key in values:
+            lines.append(f"{key}={values[key]}")
+            seen.add(key)
+    for key in sorted(values):
+        if key not in seen:
+            lines.append(f"{key}={values[key]}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")

--- a/tests/integration/test_ui_routes.py
+++ b/tests/integration/test_ui_routes.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import build_container, create_app
+from obsidian_agent.config import Settings
+
+
+def test_dashboard_serves_html() -> None:
+    client = TestClient(create_app())
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "LLM2Obsidian Control Panel" in response.text
+
+
+def test_ui_config_roundtrip_updates_env_file(tmp_path: Path) -> None:
+    app = create_app()
+    app.state.ui_env_path = tmp_path / ".env"
+    client = TestClient(app)
+
+    payload = {
+        "llm_provider": "deepseek",
+        "deepseek_api_key": "demo-key",
+        "deepseek_base_url": "https://api.deepseek.com",
+        "deepseek_model": "deepseek-chat",
+        "openai_api_key": "",
+        "openai_base_url": "https://api.openai.com/v1",
+        "openai_model": "gpt-4.1-mini",
+        "obsidian_mode": "filesystem",
+        "obsidian_api_url": "",
+        "obsidian_api_key": "",
+        "obsidian_verify_ssl": False,
+        "vault_root": str(tmp_path / "vault"),
+        "sqlite_path": str(tmp_path / "db.sqlite3"),
+        "vector_store_path": str(tmp_path / "vectors.json"),
+        "log_level": "INFO",
+        "dry_run": True,
+        "http_timeout_seconds": 12,
+        "http_retry_attempts": 2,
+        "http_retry_backoff_seconds": 0.2,
+        "review_folder": "90 Review",
+        "inbox_folder": "00 Inbox",
+    }
+
+    response = client.put("/ui/api/config", json=payload)
+    assert response.status_code == 200
+    env_text = (tmp_path / ".env").read_text(encoding="utf-8")
+    assert "DEEPSEEK_API_KEY=demo-key" in env_text
+    assert "DRY_RUN=true" in env_text
+
+    loaded = client.get("/ui/api/config")
+    assert loaded.status_code == 200
+    assert loaded.json()["raw_env"]["DEEPSEEK_API_KEY"] == "demo-key"
+
+
+def test_ui_seed_demo_returns_paths(tmp_path: Path) -> None:
+    app = create_app()
+    settings = Settings(
+        obsidian_mode="filesystem",
+        vault_root=tmp_path / "vault",
+        sqlite_path=tmp_path / "db.sqlite3",
+        vector_store_path=tmp_path / "vectors.json",
+    )
+    app.state.container = build_container(settings)
+    client = TestClient(app)
+    response = client.post("/ui/api/seed-demo")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["seeded"] is True
+    assert payload["count"] >= 1


### PR DESCRIPTION
# Summary
- Added a built-in browser control panel served by FastAPI at `/` and `/ui`.
- Added UI APIs for runtime inspection, `.env` editing, runtime reload, demo seeding, reindexing, and weekly digest execution.
- Added static UI assets for configuration, capture, search, review queue inspection, and maintenance actions.
- Added a Windows one-command startup script and integration coverage for the new UI routes.

# Risk
- The dashboard is intended for local operator use. It exposes writable configuration and should not be deployed as a public internet-facing UI without additional authentication.
- Saving config reloads settings from the selected `.env` file, but explicit process environment variables can still override file values.
- Existing local temp-directory permission warnings from previous pytest runs still appear in `git status`, but they are unrelated to the UI changes.

# Test Evidence
- `ruff check src tests scripts --select F,E9,B`
- `python -m compileall src scripts tests`
- Manual smoke: `/`, `/ui/api/runtime`, `/ui/api/config`, `/ui/api/seed-demo`, `/ui/api/reindex`, and `/search` all succeeded through the new UI-facing flow.

# Rollback Plan
- Revert commit `addab18`, or close this PR without merging.
