### PR TITLE
feat: add UI language switcher for issue #17

### DIFF
--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -1,5 +1,170 @@
 const consoleOutput = document.getElementById("consoleOutput");
 const configForm = document.getElementById("configForm");
+const languageSelect = document.getElementById("languageSelect");
+
+const translations = {
+  "zh-CN": {
+    documentTitle: "LLM2Obsidian 控制台",
+    heroTitle: "控制台",
+    heroLede: "配置模型与 Obsidian 连接，并在浏览器里直接运行核心工作流。",
+    languageLabel: "语言",
+    healthChecking: "检查中",
+    envLoading: "正在加载运行时信息...",
+    reloadRuntime: "重新加载运行时",
+    runtimeConfig: "运行配置",
+    saveConfig: "保存配置",
+    llmProvider: "LLM 提供方",
+    obsidianMode: "Obsidian 模式",
+    vaultRoot: "Vault 根目录",
+    sqlitePath: "SQLite 路径",
+    vectorStorePath: "向量存储路径",
+    obsidianApiUrl: "Obsidian API URL",
+    obsidianApiKey: "Obsidian API Key",
+    deepseekApiKey: "DeepSeek API Key",
+    deepseekBaseUrl: "DeepSeek Base URL",
+    deepseekModel: "DeepSeek 模型",
+    openaiApiKey: "OpenAI API Key",
+    openaiBaseUrl: "OpenAI Base URL",
+    openaiModel: "OpenAI 模型",
+    logLevel: "日志级别",
+    reviewFolder: "Review 目录",
+    inboxFolder: "Inbox 目录",
+    httpTimeout: "HTTP 超时",
+    retryAttempts: "重试次数",
+    retryBackoff: "重试退避",
+    verifySsl: "校验 SSL",
+    dryRun: "Dry Run 预演",
+    quickActions: "快捷操作",
+    seedDemo: "生成演示知识库",
+    reindex: "重建索引",
+    weeklyDigest: "生成周报",
+    captureText: "文本采集",
+    captureTitlePlaceholder: "标题",
+    captureTextPlaceholder: "粘贴一段笔记、文章摘录或想法...",
+    captureToInbox: "采集到 Inbox",
+    search: "搜索",
+    searchPlaceholder: "搜索笔记",
+    runSearch: "执行搜索",
+    reviewQueue: "Review 队列",
+    refresh: "刷新",
+    maintenance: "维护",
+    duplicates: "重复候选",
+    orphans: "孤儿笔记",
+    metadataIssues: "元数据问题",
+    console: "控制台",
+    clear: "清空",
+    consoleWaiting: "等待操作...",
+    noItemsTitle: "没有结果",
+    noItemsBody: "当前结果集为空。",
+    noTargetNote: "没有目标笔记",
+    reviewConnector: "·",
+    scoreLabel: "分数",
+    runtimeLoaded: "已加载运行时",
+    reviewQueueRefreshed: "已刷新 Review 队列",
+    configSaved: "已保存配置",
+    runtimeReloaded: "已重新加载运行时",
+    demoVaultSeeded: "已生成演示知识库",
+    vaultReindexed: "已重建索引",
+    weeklyDigestDone: "周报任务结果",
+    captureComplete: "采集完成",
+    searchComplete: "搜索完成",
+    startupError: "启动错误",
+    consoleCleared: "控制台已清空。",
+    maintenancePrefix: "维护结果",
+  },
+  en: {
+    documentTitle: "LLM2Obsidian Control Panel",
+    heroTitle: "Control Panel",
+    heroLede: "Configure providers, connect Obsidian, and run the core workflows in the browser.",
+    languageLabel: "Language",
+    healthChecking: "checking",
+    envLoading: "Loading runtime information...",
+    reloadRuntime: "Reload Runtime",
+    runtimeConfig: "Runtime Config",
+    saveConfig: "Save Config",
+    llmProvider: "LLM Provider",
+    obsidianMode: "Obsidian Mode",
+    vaultRoot: "Vault Root",
+    sqlitePath: "SQLite Path",
+    vectorStorePath: "Vector Store Path",
+    obsidianApiUrl: "Obsidian API URL",
+    obsidianApiKey: "Obsidian API Key",
+    deepseekApiKey: "DeepSeek API Key",
+    deepseekBaseUrl: "DeepSeek Base URL",
+    deepseekModel: "DeepSeek Model",
+    openaiApiKey: "OpenAI API Key",
+    openaiBaseUrl: "OpenAI Base URL",
+    openaiModel: "OpenAI Model",
+    logLevel: "Log Level",
+    reviewFolder: "Review Folder",
+    inboxFolder: "Inbox Folder",
+    httpTimeout: "HTTP Timeout",
+    retryAttempts: "Retry Attempts",
+    retryBackoff: "Retry Backoff",
+    verifySsl: "Verify SSL",
+    dryRun: "Dry Run",
+    quickActions: "Quick Actions",
+    seedDemo: "Seed Demo Vault",
+    reindex: "Reindex Vault",
+    weeklyDigest: "Weekly Digest",
+    captureText: "Capture Text",
+    captureTitlePlaceholder: "Title",
+    captureTextPlaceholder: "Paste a note, article excerpt, or idea...",
+    captureToInbox: "Capture to Inbox",
+    search: "Search",
+    searchPlaceholder: "Search notes",
+    runSearch: "Run Search",
+    reviewQueue: "Review Queue",
+    refresh: "Refresh",
+    maintenance: "Maintenance",
+    duplicates: "Duplicates",
+    orphans: "Orphans",
+    metadataIssues: "Metadata Issues",
+    console: "Console",
+    clear: "Clear",
+    consoleWaiting: "Waiting for action...",
+    noItemsTitle: "No items",
+    noItemsBody: "The result set is empty.",
+    noTargetNote: "No target note",
+    reviewConnector: "·",
+    scoreLabel: "score",
+    runtimeLoaded: "Runtime loaded",
+    reviewQueueRefreshed: "Review queue refreshed",
+    configSaved: "Config saved",
+    runtimeReloaded: "Runtime reloaded",
+    demoVaultSeeded: "Demo vault seeded",
+    vaultReindexed: "Vault reindexed",
+    weeklyDigestDone: "Weekly digest",
+    captureComplete: "Capture complete",
+    searchComplete: "Search complete",
+    startupError: "Startup error",
+    consoleCleared: "Console cleared.",
+    maintenancePrefix: "Maintenance",
+  },
+};
+
+function currentLanguage() {
+  const stored = window.localStorage.getItem("ui-language");
+  return stored && translations[stored] ? stored : "zh-CN";
+}
+
+function t(key) {
+  return translations[currentLanguage()][key] || key;
+}
+
+function applyLanguage(lang) {
+  window.localStorage.setItem("ui-language", lang);
+  document.documentElement.lang = lang;
+  document.title = translations[lang].documentTitle;
+  languageSelect.value = lang;
+  for (const node of document.querySelectorAll("[data-i18n]")) {
+    node.textContent = translations[lang][node.dataset.i18n] || node.textContent;
+  }
+  for (const node of document.querySelectorAll("[data-i18n-placeholder]")) {
+    node.placeholder =
+      translations[lang][node.dataset.i18nPlaceholder] || node.placeholder;
+  }
+}
 
 function logResult(label, payload) {
   const rendered = typeof payload === "string" ? payload : JSON.stringify(payload, null, 2);
@@ -61,7 +226,7 @@ function getFormValues() {
 function renderCards(target, items, formatter) {
   target.innerHTML = "";
   if (!items.length) {
-    target.innerHTML = '<div class="result-card"><strong>No items</strong><small>The result set is empty.</small></div>';
+    target.innerHTML = `<div class="result-card"><strong>${t("noItemsTitle")}</strong><small>${t("noItemsBody")}</small></div>`;
     return;
   }
   for (const item of items) {
@@ -77,17 +242,17 @@ async function loadRuntime() {
   document.getElementById("healthBadge").textContent = runtime.health;
   document.getElementById("envPath").textContent = runtime.env_path;
   setFormValues(runtime.settings);
-  logResult("Runtime loaded", runtime);
+  logResult(t("runtimeLoaded"), runtime);
 }
 
 async function loadReviews() {
   const payload = await api("/review/pending");
   renderCards(document.getElementById("reviewResults"), payload.items, (item) => `
-    <strong>#${item.id} · ${item.proposal_type}</strong>
+    <strong>#${item.id} ${t("reviewConnector")} ${item.proposal_type}</strong>
     <div>${item.source_note_path || ""}</div>
-    <small>${item.target_note_path || "No target note"} · ${item.risk_level}</small>
+    <small>${item.target_note_path || t("noTargetNote")} ${t("reviewConnector")} ${item.risk_level}</small>
   `);
-  logResult("Review queue refreshed", payload);
+  logResult(t("reviewQueueRefreshed"), payload);
 }
 
 async function runMaintenance(target) {
@@ -95,9 +260,9 @@ async function runMaintenance(target) {
   renderCards(document.getElementById("maintenanceResults"), payload.items, (item) => `
     <strong>${item.path}</strong>
     <div>${item.reason}</div>
-    <small>score: ${item.score}</small>
+    <small>${t("scoreLabel")}: ${item.score}</small>
   `);
-  logResult(`Maintenance ${target}`, payload);
+  logResult(`${t("maintenancePrefix")} ${target}`, payload);
 }
 
 document.getElementById("saveConfig").addEventListener("click", async () => {
@@ -105,24 +270,24 @@ document.getElementById("saveConfig").addEventListener("click", async () => {
     method: "PUT",
     body: JSON.stringify(getFormValues()),
   });
-  logResult("Config saved", payload);
+  logResult(t("configSaved"), payload);
   setFormValues(payload.settings);
 });
 
 document.getElementById("reloadRuntime").addEventListener("click", async () => {
   const payload = await api("/ui/api/reload", { method: "POST" });
-  logResult("Runtime reloaded", payload);
+  logResult(t("runtimeReloaded"), payload);
   setFormValues(payload.settings);
 });
 
 document.getElementById("seedDemo").addEventListener("click", async () => {
   const payload = await api("/ui/api/seed-demo", { method: "POST" });
-  logResult("Demo vault seeded", payload);
+  logResult(t("demoVaultSeeded"), payload);
 });
 
 document.getElementById("reindex").addEventListener("click", async () => {
   const payload = await api("/ui/api/reindex", { method: "POST" });
-  logResult("Vault reindexed", payload);
+  logResult(t("vaultReindexed"), payload);
 });
 
 document.getElementById("runDigest").addEventListener("click", async () => {
@@ -130,7 +295,7 @@ document.getElementById("runDigest").addEventListener("click", async () => {
     method: "POST",
     body: JSON.stringify({ week_key: document.getElementById("weekKey").value }),
   });
-  logResult("Weekly digest", payload);
+  logResult(t("weeklyDigestDone"), payload);
 });
 
 document.getElementById("captureSubmit").addEventListener("click", async () => {
@@ -142,7 +307,7 @@ document.getElementById("captureSubmit").addEventListener("click", async () => {
       source_ref: "ui",
     }),
   });
-  logResult("Capture complete", payload);
+  logResult(t("captureComplete"), payload);
 });
 
 document.getElementById("searchSubmit").addEventListener("click", async () => {
@@ -151,9 +316,9 @@ document.getElementById("searchSubmit").addEventListener("click", async () => {
   renderCards(document.getElementById("searchResults"), payload.results, (item) => `
     <strong>${item.path}</strong>
     <div>${item.reason}</div>
-    <small>score: ${item.score}</small>
+    <small>${t("scoreLabel")}: ${item.score}</small>
   `);
-  logResult("Search complete", payload);
+  logResult(t("searchComplete"), payload);
 });
 
 document.getElementById("refreshReviews").addEventListener("click", loadReviews);
@@ -168,9 +333,15 @@ for (const button of document.querySelectorAll(".maintenance-trigger")) {
 }
 
 document.getElementById("clearConsole").addEventListener("click", () => {
-  consoleOutput.textContent = "Console cleared.";
+  consoleOutput.textContent = t("consoleCleared");
 });
+
+languageSelect.addEventListener("change", () => {
+  applyLanguage(languageSelect.value);
+});
+
+applyLanguage(currentLanguage());
 
 loadRuntime()
   .then(loadReviews)
-  .catch((error) => logResult("Startup error", error.message));
+  .catch((error) => logResult(t("startupError"), error.message));

--- a/src/obsidian_agent/ui/index.html
+++ b/src/obsidian_agent/ui/index.html
@@ -1,9 +1,9 @@
 <!doctype html>
-<html lang="en">
+<html lang="zh-CN">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>LLM2Obsidian Control Panel</title>
+    <title>LLM2Obsidian 控制台</title>
     <link rel="stylesheet" href="/ui/assets/styles.css">
   </head>
   <body>
@@ -11,113 +11,121 @@
       <header class="hero">
         <div class="hero-copy">
           <p class="eyebrow">LLM2Obsidian</p>
-          <h1>Control Panel</h1>
-          <p class="lede">
-            Configure providers, connect Obsidian, and run the core workflows without touching
-            curl.
+          <div class="hero-topline">
+            <h1 data-i18n="heroTitle">控制台</h1>
+            <label class="language-switcher">
+              <span data-i18n="languageLabel">语言</span>
+              <select id="languageSelect" aria-label="Language">
+                <option value="zh-CN">简体中文</option>
+                <option value="en">English</option>
+              </select>
+            </label>
+          </div>
+          <p class="lede" data-i18n="heroLede">
+            配置模型与 Obsidian 连接，并在浏览器里直接运行核心工作流。
           </p>
         </div>
         <div class="status-card">
-          <span id="healthBadge" class="badge">checking</span>
-          <p id="envPath" class="env-path">Loading runtime...</p>
-          <button id="reloadRuntime" class="secondary-button">Reload Runtime</button>
+          <span id="healthBadge" class="badge" data-i18n="healthChecking">检查中</span>
+          <p id="envPath" class="env-path" data-i18n="envLoading">正在加载运行时信息...</p>
+          <button id="reloadRuntime" class="secondary-button" data-i18n="reloadRuntime">重新加载运行时</button>
         </div>
       </header>
 
       <main class="dashboard-grid">
         <section class="panel panel-wide">
           <div class="panel-head">
-            <h2>Runtime Config</h2>
-            <button id="saveConfig" class="primary-button">Save Config</button>
+            <h2 data-i18n="runtimeConfig">运行配置</h2>
+            <button id="saveConfig" class="primary-button" data-i18n="saveConfig">保存配置</button>
           </div>
           <form id="configForm" class="config-grid">
-            <label><span>LLM Provider</span><input name="llm_provider" value="deepseek"></label>
-            <label><span>Obsidian Mode</span><input name="obsidian_mode" value="auto"></label>
-            <label><span>Vault Root</span><input name="vault_root"></label>
-            <label><span>SQLite Path</span><input name="sqlite_path"></label>
-            <label><span>Vector Store Path</span><input name="vector_store_path"></label>
-            <label><span>Obsidian API URL</span><input name="obsidian_api_url"></label>
-            <label><span>Obsidian API Key</span><input name="obsidian_api_key" type="password"></label>
-            <label><span>DeepSeek API Key</span><input name="deepseek_api_key" type="password"></label>
-            <label><span>DeepSeek Base URL</span><input name="deepseek_base_url"></label>
-            <label><span>DeepSeek Model</span><input name="deepseek_model"></label>
-            <label><span>OpenAI API Key</span><input name="openai_api_key" type="password"></label>
-            <label><span>OpenAI Base URL</span><input name="openai_base_url"></label>
-            <label><span>OpenAI Model</span><input name="openai_model"></label>
-            <label><span>Log Level</span><input name="log_level"></label>
-            <label><span>Review Folder</span><input name="review_folder"></label>
-            <label><span>Inbox Folder</span><input name="inbox_folder"></label>
-            <label><span>HTTP Timeout</span><input name="http_timeout_seconds" type="number" step="0.5"></label>
-            <label><span>Retry Attempts</span><input name="http_retry_attempts" type="number" step="1"></label>
-            <label><span>Retry Backoff</span><input name="http_retry_backoff_seconds" type="number" step="0.1"></label>
-            <label class="toggle"><span>Verify SSL</span><input name="obsidian_verify_ssl" type="checkbox"></label>
-            <label class="toggle"><span>Dry Run</span><input name="dry_run" type="checkbox"></label>
+            <label><span data-i18n="llmProvider">LLM 提供方</span><input name="llm_provider" value="deepseek"></label>
+            <label><span data-i18n="obsidianMode">Obsidian 模式</span><input name="obsidian_mode" value="auto"></label>
+            <label><span data-i18n="vaultRoot">Vault 根目录</span><input name="vault_root"></label>
+            <label><span data-i18n="sqlitePath">SQLite 路径</span><input name="sqlite_path"></label>
+            <label><span data-i18n="vectorStorePath">向量存储路径</span><input name="vector_store_path"></label>
+            <label><span data-i18n="obsidianApiUrl">Obsidian API URL</span><input name="obsidian_api_url"></label>
+            <label><span data-i18n="obsidianApiKey">Obsidian API Key</span><input name="obsidian_api_key" type="password"></label>
+            <label><span data-i18n="deepseekApiKey">DeepSeek API Key</span><input name="deepseek_api_key" type="password"></label>
+            <label><span data-i18n="deepseekBaseUrl">DeepSeek Base URL</span><input name="deepseek_base_url"></label>
+            <label><span data-i18n="deepseekModel">DeepSeek 模型</span><input name="deepseek_model"></label>
+            <label><span data-i18n="openaiApiKey">OpenAI API Key</span><input name="openai_api_key" type="password"></label>
+            <label><span data-i18n="openaiBaseUrl">OpenAI Base URL</span><input name="openai_base_url"></label>
+            <label><span data-i18n="openaiModel">OpenAI 模型</span><input name="openai_model"></label>
+            <label><span data-i18n="logLevel">日志级别</span><input name="log_level"></label>
+            <label><span data-i18n="reviewFolder">Review 目录</span><input name="review_folder"></label>
+            <label><span data-i18n="inboxFolder">Inbox 目录</span><input name="inbox_folder"></label>
+            <label><span data-i18n="httpTimeout">HTTP 超时</span><input name="http_timeout_seconds" type="number" step="0.5"></label>
+            <label><span data-i18n="retryAttempts">重试次数</span><input name="http_retry_attempts" type="number" step="1"></label>
+            <label><span data-i18n="retryBackoff">重试退避</span><input name="http_retry_backoff_seconds" type="number" step="0.1"></label>
+            <label class="toggle"><span data-i18n="verifySsl">校验 SSL</span><input name="obsidian_verify_ssl" type="checkbox"></label>
+            <label class="toggle"><span data-i18n="dryRun">Dry Run 预演</span><input name="dry_run" type="checkbox"></label>
           </form>
         </section>
 
         <section class="panel">
           <div class="panel-head">
-            <h2>Quick Actions</h2>
+            <h2 data-i18n="quickActions">快捷操作</h2>
           </div>
           <div class="stack">
-            <button id="seedDemo" class="primary-button">Seed Demo Vault</button>
-            <button id="reindex" class="primary-button">Reindex Vault</button>
+            <button id="seedDemo" class="primary-button" data-i18n="seedDemo">生成演示知识库</button>
+            <button id="reindex" class="primary-button" data-i18n="reindex">重建索引</button>
             <div class="inline-form">
               <input id="weekKey" value="2026-W11" aria-label="Week key">
-              <button id="runDigest" class="secondary-button">Weekly Digest</button>
+              <button id="runDigest" class="secondary-button" data-i18n="weeklyDigest">生成周报</button>
             </div>
           </div>
         </section>
 
         <section class="panel">
           <div class="panel-head">
-            <h2>Capture Text</h2>
+            <h2 data-i18n="captureText">文本采集</h2>
           </div>
           <div class="stack">
-            <input id="captureTitle" placeholder="Title">
-            <textarea id="captureText" rows="8" placeholder="Paste a note, article excerpt, or idea..."></textarea>
-            <button id="captureSubmit" class="primary-button">Capture to Inbox</button>
+            <input id="captureTitle" data-i18n-placeholder="captureTitlePlaceholder" placeholder="标题">
+            <textarea id="captureText" rows="8" data-i18n-placeholder="captureTextPlaceholder" placeholder="粘贴一段笔记、文章摘录或想法..."></textarea>
+            <button id="captureSubmit" class="primary-button" data-i18n="captureToInbox">采集到 Inbox</button>
           </div>
         </section>
 
         <section class="panel">
           <div class="panel-head">
-            <h2>Search</h2>
+            <h2 data-i18n="search">搜索</h2>
           </div>
           <div class="stack">
-            <input id="searchQuery" placeholder="Search notes">
-            <button id="searchSubmit" class="secondary-button">Run Search</button>
+            <input id="searchQuery" data-i18n-placeholder="searchPlaceholder" placeholder="搜索笔记">
+            <button id="searchSubmit" class="secondary-button" data-i18n="runSearch">执行搜索</button>
             <div id="searchResults" class="result-list"></div>
           </div>
         </section>
 
         <section class="panel">
           <div class="panel-head">
-            <h2>Review Queue</h2>
-            <button id="refreshReviews" class="ghost-button">Refresh</button>
+            <h2 data-i18n="reviewQueue">Review 队列</h2>
+            <button id="refreshReviews" class="ghost-button" data-i18n="refresh">刷新</button>
           </div>
           <div id="reviewResults" class="result-list"></div>
         </section>
 
         <section class="panel">
           <div class="panel-head">
-            <h2>Maintenance</h2>
-            <button id="refreshMaintenance" class="ghost-button">Refresh</button>
+            <h2 data-i18n="maintenance">维护</h2>
+            <button id="refreshMaintenance" class="ghost-button" data-i18n="refresh">刷新</button>
           </div>
           <div class="stack maintenance-buttons">
-            <button data-target="duplicates" class="ghost-button maintenance-trigger">Duplicates</button>
-            <button data-target="orphans" class="ghost-button maintenance-trigger">Orphans</button>
-            <button data-target="metadata-issues" class="ghost-button maintenance-trigger">Metadata Issues</button>
+            <button data-target="duplicates" class="ghost-button maintenance-trigger" data-i18n="duplicates">重复候选</button>
+            <button data-target="orphans" class="ghost-button maintenance-trigger" data-i18n="orphans">孤儿笔记</button>
+            <button data-target="metadata-issues" class="ghost-button maintenance-trigger" data-i18n="metadataIssues">元数据问题</button>
           </div>
           <div id="maintenanceResults" class="result-list"></div>
         </section>
 
         <section class="panel panel-wide console-panel">
           <div class="panel-head">
-            <h2>Console</h2>
-            <button id="clearConsole" class="ghost-button">Clear</button>
+            <h2 data-i18n="console">控制台</h2>
+            <button id="clearConsole" class="ghost-button" data-i18n="clear">清空</button>
           </div>
-          <pre id="consoleOutput" class="console-output">Waiting for action...</pre>
+          <pre id="consoleOutput" class="console-output" data-i18n="consoleWaiting">等待操作...</pre>
         </section>
       </main>
     </div>

--- a/src/obsidian_agent/ui/styles.css
+++ b/src/obsidian_agent/ui/styles.css
@@ -51,6 +51,26 @@ body {
   padding: 28px;
 }
 
+.hero-topline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+}
+
+.language-switcher {
+  min-width: 148px;
+}
+
+.language-switcher select {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.82);
+  padding: 10px 14px;
+  color: var(--ink);
+  font: inherit;
+}
+
 .status-card {
   padding: 24px;
   display: flex;
@@ -253,5 +273,9 @@ button:hover {
   .config-grid,
   .maintenance-buttons {
     grid-template-columns: 1fr;
+  }
+
+  .hero-topline {
+    flex-direction: column;
   }
 }

--- a/tests/integration/test_ui_routes.py
+++ b/tests/integration/test_ui_routes.py
@@ -10,7 +10,8 @@ def test_dashboard_serves_html() -> None:
     client = TestClient(create_app())
     response = client.get("/")
     assert response.status_code == 200
-    assert "LLM2Obsidian Control Panel" in response.text
+    assert "LLM2Obsidian 控制台" in response.text
+    assert "简体中文" in response.text
 
 
 def test_ui_config_roundtrip_updates_env_file(tmp_path: Path) -> None:


### PR DESCRIPTION
# Summary
- Added a client-side UI language switcher to the built-in control panel.
- Set Simplified Chinese as the default dashboard language.
- Added an English toggle without changing any backend workflow behavior.
- Updated the UI route test to check for the new default language content.

# Risk
- The patch is intentionally UI-only and does not change any API payloads or workflow semantics.
- Language preference is stored in `localStorage`, so switching is browser-local rather than account-global.
- The local user-modified `docs/specs/git-flow.md` file remains excluded from this branch.

# Test Evidence
- `ruff check src tests --select F,E9,B`
- `python -m compileall src tests`
- Manual smoke verified the dashboard HTML now renders Chinese labels by default and exposes the language selector.

# Rollback Plan
- Revert commit `9332c73`, or close this PR without merging.
