### PR TITLE
feat: implement issue #24 teaching pack generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ python -m compileall src scripts
 - `POST /maintenance/weekly-digest`
 - `POST /smart/error-capture`
 - `POST /smart/node-pack`
+- `POST /smart/teach`
+- `GET /smart/related-nodes`
 
 ## Delivery Notes
 
@@ -87,7 +89,7 @@ python -m compileall src scripts
 - `DRY_RUN=true` returns action previews for write paths instead of mutating the vault.
 - Prompt assets live under `src/obsidian_agent/prompts/` and are tracked by `manifest.json`.
 - The built-in control panel is served from `/` and `/ui`.
-- The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, search notes, inspect review items, and run maintenance jobs.
+- The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, search notes, inspect review items, and run maintenance jobs.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -70,6 +70,20 @@ curl -X POST http://127.0.0.1:8000/smart/node-pack ^
   -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5}"
 ```
 
+To generate a teaching-oriented explanation from that relation pack:
+
+```bash
+curl -X POST http://127.0.0.1:8000/smart/teach ^
+  -H "Content-Type: application/json" ^
+  -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5}"
+```
+
+To inspect nearby smart nodes without generating a teaching pack:
+
+```bash
+curl "http://127.0.0.1:8000/smart/related-nodes?node_key=error/sizeof-vs-strlen&top_k=5"
+```
+
 ## 6. Generate and Apply a Review
 
 1. Call `POST /review/generate` with the new Inbox note path.

--- a/src/obsidian_agent/api/routes_smart.py
+++ b/src/obsidian_agent/api/routes_smart.py
@@ -2,12 +2,14 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 
 from obsidian_agent.api.deps import get_api_container
-from fastapi import HTTPException, status
-
-from obsidian_agent.domain.schemas import ErrorCaptureRequest, NodePackRequest
+from obsidian_agent.domain.schemas import (
+    ErrorCaptureRequest,
+    NodePackRequest,
+    TeachingPackRequest,
+)
 
 router = APIRouter(prefix="/smart", tags=["smart"])
 ContainerDep = Annotated[object, Depends(get_api_container)]
@@ -35,3 +37,28 @@ async def smart_node_pack(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     return response.model_dump(mode="json")
+
+
+@router.post("/teach")
+async def smart_teach(
+    request: TeachingPackRequest,
+    container: ContainerDep,
+) -> dict[str, object]:
+    try:
+        response = await container.teaching_planner_service.build_teaching_pack(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return response.model_dump(mode="json")
+
+
+@router.get("/related-nodes")
+async def smart_related_nodes(
+    node_key: str = Query(min_length=3),
+    top_k: int = Query(default=5, ge=1, le=10),
+    container: object = Depends(get_api_container),
+) -> dict[str, object]:
+    try:
+        items = await container.smart_query_service.related_nodes(node_key=node_key, top_k=top_k)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return {"node_key": node_key, "items": [item.model_dump(mode="json") for item in items]}

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -32,6 +32,8 @@ from obsidian_agent.services.review_service import ReviewService
 from obsidian_agent.services.routing_policy_service import RoutingPolicyService
 from obsidian_agent.services.smart_capture_service import SmartCaptureService
 from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
+from obsidian_agent.services.smart_query_service import SmartQueryService
+from obsidian_agent.services.teaching_planner_service import TeachingPlannerService
 from obsidian_agent.services.synthesis_service import SynthesisService
 from obsidian_agent.services.weakness_diagnoser_service import WeaknessDiagnoserService
 from obsidian_agent.storage.db import create_session_factory
@@ -62,6 +64,8 @@ class AppContainer:
     link_workflow: LinkWorkflow
     smart_capture_service: SmartCaptureService
     smart_node_pack_service: SmartNodePackService
+    smart_query_service: SmartQueryService
+    teaching_planner_service: TeachingPlannerService
 
 
 def _template_path(name: str) -> Path:
@@ -177,6 +181,11 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         relation_miner=RelationMinerService(routing_policy),
         context_compressor=ContextCompressorService(routing_policy),
     )
+    smart_query_service = SmartQueryService(smart_node_pack_service)
+    teaching_planner_service = TeachingPlannerService(
+        smart_node_pack_service=smart_node_pack_service,
+        routing_policy=routing_policy,
+    )
     return AppContainer(
         settings=settings,
         session_factory=session_factory,
@@ -194,6 +203,8 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         link_workflow=link_workflow,
         smart_capture_service=smart_capture_service,
         smart_node_pack_service=smart_node_pack_service,
+        smart_query_service=smart_query_service,
+        teaching_planner_service=teaching_planner_service,
     )
 
 

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -231,3 +231,27 @@ class NodePackRequest(BaseModel):
 class SmartNodePackResponse(BaseModel):
     pack: RelationPack
     stored_edges: int = 0
+
+
+class RelatedNodesRequest(BaseModel):
+    node_key: str = Field(min_length=3)
+    top_k: int = Field(default=5, ge=1, le=10)
+
+
+class TeachingPackRequest(BaseModel):
+    node_key: str = Field(min_length=3)
+    top_k: int = Field(default=5, ge=1, le=10)
+
+
+class TeachingSection(BaseModel):
+    heading: str
+    body: str
+
+
+class TeachingPackResponse(BaseModel):
+    pack: RelationPack
+    title: str
+    overview: str
+    sections: list[TeachingSection] = Field(default_factory=list)
+    drills: list[str] = Field(default_factory=list)
+    markdown: str

--- a/src/obsidian_agent/services/routing_policy_service.py
+++ b/src/obsidian_agent/services/routing_policy_service.py
@@ -16,3 +16,10 @@ class RoutingPolicyService:
         if self.local_llm_service and self.local_llm_service.client is not None:
             return self.local_llm_service
         return self.primary_llm_service
+
+    def for_teaching_task(self) -> LLMService:
+        if self.primary_llm_service and self.primary_llm_service.client is not None:
+            return self.primary_llm_service
+        if self.local_llm_service and self.local_llm_service.client is not None:
+            return self.local_llm_service
+        return self.primary_llm_service

--- a/src/obsidian_agent/services/smart_query_service.py
+++ b/src/obsidian_agent/services/smart_query_service.py
@@ -1,0 +1,17 @@
+"""Read-oriented helpers for smart node lookups."""
+
+from __future__ import annotations
+
+from obsidian_agent.domain.schemas import KnowledgeNodeSchema
+from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
+
+
+class SmartQueryService:
+    """Small query facade for UI-friendly smart lookups."""
+
+    def __init__(self, smart_node_pack_service: SmartNodePackService) -> None:
+        self.smart_node_pack_service = smart_node_pack_service
+
+    async def related_nodes(self, node_key: str, top_k: int = 5) -> list[KnowledgeNodeSchema]:
+        response = await self.smart_node_pack_service.build_node_pack(node_key=node_key, top_k=top_k)
+        return response.pack.related_nodes

--- a/src/obsidian_agent/services/teaching_planner_service.py
+++ b/src/obsidian_agent/services/teaching_planner_service.py
@@ -1,0 +1,146 @@
+"""Generate teaching-oriented outputs from relation packs."""
+
+from __future__ import annotations
+
+from obsidian_agent.domain.schemas import (
+    RelationPack,
+    TeachingPackRequest,
+    TeachingPackResponse,
+    TeachingSection,
+)
+from obsidian_agent.services.routing_policy_service import RoutingPolicyService
+from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
+
+
+class TeachingPlannerService:
+    """Turn a relation pack into a teaching pack preview."""
+
+    def __init__(
+        self,
+        smart_node_pack_service: SmartNodePackService,
+        routing_policy: RoutingPolicyService,
+    ) -> None:
+        self.smart_node_pack_service = smart_node_pack_service
+        self.routing_policy = routing_policy
+
+    async def build_teaching_pack(self, request: TeachingPackRequest) -> TeachingPackResponse:
+        pack_response = await self.smart_node_pack_service.build_node_pack(
+            node_key=request.node_key,
+            top_k=request.top_k,
+        )
+        pack = pack_response.pack
+        payload = await self._plan_from_model(pack)
+        if payload is None:
+            payload = self._fallback_plan(pack)
+        markdown = self._render_markdown(
+            title=payload["title"],
+            overview=payload["overview"],
+            sections=payload["sections"],
+            drills=payload["drills"],
+        )
+        return TeachingPackResponse(
+            pack=pack,
+            title=payload["title"],
+            overview=payload["overview"],
+            sections=payload["sections"],
+            drills=payload["drills"],
+            markdown=markdown,
+        )
+
+    async def _plan_from_model(self, pack: RelationPack) -> dict[str, object] | None:
+        llm_service = self.routing_policy.for_teaching_task()
+        raw = await llm_service.run_structured_task(
+            instructions=(
+                "Return JSON with keys: title, overview, sections, drills. "
+                "sections must be a list of objects with heading and body. "
+                "drills must be a list of short practice prompts. "
+                "Focus on teaching the anchor concept using the related nodes and relations."
+            ),
+            input_text="\n".join(
+                [
+                    f"Anchor: {pack.anchor.title}",
+                    f"Anchor summary: {pack.anchor.summary}",
+                    f"Relation summary: {pack.summary}",
+                    "Related nodes:",
+                    *[f"- {node.title}: {node.summary}" for node in pack.related_nodes],
+                    "Edges:",
+                    *[
+                        f"- {edge.relation_type.value} -> {edge.to_node_key}: {edge.reason}"
+                        for edge in pack.edges
+                    ],
+                ]
+            ),
+        )
+        if not isinstance(raw, dict):
+            return None
+        title = str(raw.get("title") or "").strip()
+        overview = str(raw.get("overview") or "").strip()
+        sections_raw = raw.get("sections")
+        drills_raw = raw.get("drills")
+        sections: list[TeachingSection] = []
+        if isinstance(sections_raw, list):
+            for item in sections_raw:
+                if not isinstance(item, dict):
+                    continue
+                heading = str(item.get("heading") or "").strip()
+                body = str(item.get("body") or "").strip()
+                if heading and body:
+                    sections.append(TeachingSection(heading=heading, body=body))
+        drills: list[str] = []
+        if isinstance(drills_raw, list):
+            drills = [str(item).strip() for item in drills_raw if str(item).strip()]
+        if not title or not overview or not sections:
+            return None
+        return {
+            "title": title,
+            "overview": overview,
+            "sections": sections,
+            "drills": drills[:5],
+        }
+
+    def _fallback_plan(self, pack: RelationPack) -> dict[str, object]:
+        related_titles = ", ".join(node.title for node in pack.related_nodes[:3]) or "nearby concepts"
+        sections = [
+            TeachingSection(
+                heading="What To Remember",
+                body=f"{pack.anchor.title} should be understood in terms of {pack.anchor.summary}",
+            ),
+            TeachingSection(
+                heading="How It Connects",
+                body=f"This topic is most often reinforced or contrasted with {related_titles}.",
+            ),
+        ]
+        if pack.edges:
+            sections.append(
+                TeachingSection(
+                    heading="Common Failure Mode",
+                    body=pack.edges[0].reason,
+                )
+            )
+        drills = [
+            f"Explain {pack.anchor.title} in your own words.",
+            f"Write one C example that avoids the mistake behind {pack.anchor.title}.",
+        ]
+        return {
+            "title": f"Teaching Pack: {pack.anchor.title}",
+            "overview": pack.summary or pack.anchor.summary,
+            "sections": sections,
+            "drills": drills,
+        }
+
+    def _render_markdown(
+        self,
+        title: str,
+        overview: str,
+        sections: list[TeachingSection],
+        drills: list[str],
+    ) -> str:
+        lines = [f"# {title}", "", "## Overview", overview]
+        for section in sections:
+            lines.extend(["", f"## {section.heading}", section.body])
+        lines.extend(["", "## Practice Drills"])
+        if drills:
+            lines.extend(f"- {item}" for item in drills)
+        else:
+            lines.append("- Review one fresh example and explain why it works.")
+        return "\n".join(lines).strip() + "\n"

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -62,6 +62,7 @@ const translations = {
     runSmartCapture: "生成 Error Node",
     nodePackPlaceholder: "输入 node_key，例如 error/sizeof-vs-strlen",
     runNodePack: "生成 Node Pack",
+    runTeachPack: "生成 Teaching Pack",
     search: "搜索",
     searchPlaceholder: "搜索笔记",
     runSearch: "执行搜索",
@@ -89,6 +90,7 @@ const translations = {
     searchComplete: "搜索完成",
     smartCaptureComplete: "错题分析完成",
     nodePackComplete: "Node Pack 已生成",
+    teachPackComplete: "Teaching Pack 已生成",
     startupError: "启动错误",
     consoleCleared: "控制台已清空。",
     maintenancePrefix: "维护结果",
@@ -154,6 +156,7 @@ const translations = {
     runSmartCapture: "Create Error Node",
     nodePackPlaceholder: "Enter a node_key such as error/sizeof-vs-strlen",
     runNodePack: "Build Node Pack",
+    runTeachPack: "Build Teaching Pack",
     search: "Search",
     searchPlaceholder: "Search notes",
     runSearch: "Run Search",
@@ -181,6 +184,7 @@ const translations = {
     searchComplete: "Search complete",
     smartCaptureComplete: "Smart error capture complete",
     nodePackComplete: "Node pack generated",
+    teachPackComplete: "Teaching pack generated",
     startupError: "Startup error",
     consoleCleared: "Console cleared.",
     maintenancePrefix: "Maintenance",
@@ -315,16 +319,30 @@ function renderSmartResult(payload) {
   const relations = (((payload.pack || {}).edges) || [])
     .map((item) => `<li>${item.relation_type} -> ${item.to_node_key} (${item.confidence})</li>`)
     .join("");
+  const teachingSections = (payload.sections || [])
+    .map((item) => `<li><strong>${item.heading}</strong>: ${item.body}</li>`)
+    .join("");
+  const drills = (payload.drills || []).map((item) => `<li>${item}</li>`).join("");
   const preview = payload.action_preview
     ? `<small>dry-run: ${payload.action_preview.target_path}</small>`
-    : `<small>${payload.node ? payload.node.note_path || "" : payload.pack.anchor.note_path || ""}</small>`;
+    : `<small>${payload.node ? payload.node.note_path || "" : (payload.pack ? payload.pack.anchor.note_path || "" : "")}</small>`;
+  const title = payload.error ? payload.error.title : (payload.title || (payload.pack ? payload.pack.anchor.title : ""));
+  const summary = payload.error
+    ? payload.error.summary
+    : ((payload.pack && payload.pack.summary) || payload.overview || "");
+  const secondary = payload.error
+    ? payload.error.root_cause
+    : (payload.overview || (payload.pack ? payload.pack.anchor.summary : ""));
+  const listHtml = weaknesses || teachingSections || relations || drills || "<li>-</li>";
+  const markdown = payload.markdown ? `<pre class="console-output">${payload.markdown}</pre>` : "";
   target.innerHTML = `
     <article class="result-card">
-      <strong>${payload.error ? payload.error.title : payload.pack.anchor.title}</strong>
-      <div>${payload.error ? payload.error.summary : payload.pack.summary}</div>
-      <div>${payload.error ? payload.error.root_cause : payload.pack.anchor.summary}</div>
-      <ul>${weaknesses || relations || "<li>-</li>"}</ul>
+      <strong>${title}</strong>
+      <div>${summary}</div>
+      <div>${secondary}</div>
+      <ul>${listHtml}</ul>
       ${preview}
+      ${markdown}
     </article>
   `;
 }
@@ -438,6 +456,18 @@ document.getElementById("nodePackSubmit").addEventListener("click", async () => 
   });
   renderSmartResult(payload);
   logResult(t("nodePackComplete"), payload);
+});
+
+document.getElementById("teachSubmit").addEventListener("click", async () => {
+  const payload = await api("/smart/teach", {
+    method: "POST",
+    body: JSON.stringify({
+      node_key: document.getElementById("nodePackKey").value,
+      top_k: 5,
+    }),
+  });
+  renderSmartResult(payload);
+  logResult(t("teachPackComplete"), payload);
 });
 
 document.getElementById("searchSubmit").addEventListener("click", async () => {

--- a/src/obsidian_agent/ui/index.html
+++ b/src/obsidian_agent/ui/index.html
@@ -124,6 +124,7 @@
               <input id="nodePackKey" data-i18n-placeholder="nodePackPlaceholder" placeholder="输入 node_key，例如 error/sizeof-vs-strlen">
               <button id="nodePackSubmit" class="secondary-button" data-i18n="runNodePack">生成 Node Pack</button>
             </div>
+            <button id="teachSubmit" class="secondary-button" data-i18n="runTeachPack">生成 Teaching Pack</button>
             <div id="smartResults" class="result-list"></div>
           </div>
         </section>

--- a/tests/integration/test_smart_teaching.py
+++ b/tests/integration/test_smart_teaching.py
@@ -1,0 +1,96 @@
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import create_app
+from obsidian_agent.config import Settings
+from obsidian_agent.test_support import make_test_dir
+
+
+def test_smart_teach_returns_markdown_and_sections() -> None:
+    root = make_test_dir("smart_teach")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "sizeof 和 strlen 混淆",
+            "prompt": "我把 sizeof(arr) 当成字符串长度使用。",
+            "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
+            "user_analysis": "我以为 sizeof 会返回可见字符数量。",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "strlen 不统计终止符",
+            "prompt": "我没有意识到 strlen 不会包含结尾的空字符。",
+            "code": 'char arr[] = "abc"; printf("%zu", strlen(arr));',
+            "user_analysis": "我把 strlen 和内存大小混成一类了。",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    response = client.post(
+        "/smart/teach",
+        json={"node_key": first.json()["node"]["node_key"], "top_k": 5},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["title"].startswith("Teaching Pack:")
+    assert payload["sections"]
+    assert payload["markdown"].startswith("# ")
+    assert "## Practice Drills" in payload["markdown"]
+
+
+def test_smart_related_nodes_returns_related_entries() -> None:
+    root = make_test_dir("smart_related_nodes")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "pointer and array decay",
+            "prompt": "I thought arrays stayed as full arrays in function parameters.",
+            "code": 'void f(int arr[10]) { printf("%zu", sizeof(arr)); }',
+            "user_analysis": "I expected sizeof(arr) to behave like the call site.",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "array and pointer confusion",
+            "prompt": "I assumed arr and &arr had the same pointer type.",
+            "code": 'int arr[4]; int *p = arr; int (*q)[4] = &arr;',
+            "user_analysis": "I collapsed array and pointer semantics together.",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    response = client.get(
+        "/smart/related-nodes",
+        params={"node_key": first.json()["node"]["node_key"], "top_k": 5},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["items"]


### PR DESCRIPTION
# Summary
- add smart teaching pack generation from relation packs
- add related-nodes query API and UI controls for teaching pack previews
- document the new smart endpoints in README and walkthrough

# Risk
- touches smart routing, UI rendering, and provider selection for teaching tasks
- fallback planning remains in place if structured model output is incomplete

# Test Evidence
- ruff check src tests scripts --select F,E9,B
- python -m compileall src scripts tests
- pytest tests/unit/test_app.py tests/integration/test_ui_routes.py tests/integration/test_capture_variants.py tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py -q --basetemp data/test_runs/pytest_phase24_exec2
- real Ollama smoke: POST /smart/error-capture and POST /smart/teach with Qwen14B-fixed:latest returned 200

# Rollback Plan
- Revert the squash merge commit from this PR.
