### PR TITLE
feat: implement issue #26 relink workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ python -m compileall src scripts
 - `POST /smart/node-pack`
 - `POST /smart/teach`
 - `GET /smart/related-nodes`
+- `POST /smart/relink`
 
 ## Delivery Notes
 
@@ -89,7 +90,7 @@ python -m compileall src scripts
 - `DRY_RUN=true` returns action previews for write paths instead of mutating the vault.
 - Prompt assets live under `src/obsidian_agent/prompts/` and are tracked by `manifest.json`.
 - The built-in control panel is served from `/` and `/ui`.
-- The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, search notes, inspect review items, and run maintenance jobs.
+- The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, create relink reviews, search notes, inspect review items, and run maintenance jobs.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -84,6 +84,14 @@ To inspect nearby smart nodes without generating a teaching pack:
 curl "http://127.0.0.1:8000/smart/related-nodes?node_key=error/sizeof-vs-strlen&top_k=5"
 ```
 
+To rebuild relations and create a review artifact instead of mutating the note directly:
+
+```bash
+curl -X POST http://127.0.0.1:8000/smart/relink ^
+  -H "Content-Type: application/json" ^
+  -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5,\"create_review\":true,\"dry_run\":false}"
+```
+
 ## 6. Generate and Apply a Review
 
 1. Call `POST /review/generate` with the new Inbox note path.

--- a/src/obsidian_agent/api/routes_smart.py
+++ b/src/obsidian_agent/api/routes_smart.py
@@ -8,6 +8,7 @@ from obsidian_agent.api.deps import get_api_container
 from obsidian_agent.domain.schemas import (
     ErrorCaptureRequest,
     NodePackRequest,
+    SmartRelinkRequest,
     TeachingPackRequest,
 )
 
@@ -62,3 +63,15 @@ async def smart_related_nodes(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
     return {"node_key": node_key, "items": [item.model_dump(mode="json") for item in items]}
+
+
+@router.post("/relink")
+async def smart_relink(
+    request: SmartRelinkRequest,
+    container: ContainerDep,
+) -> dict[str, object]:
+    try:
+        response = await container.smart_relink_service.relink(request)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+    return response.model_dump(mode="json")

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -33,6 +33,7 @@ from obsidian_agent.services.routing_policy_service import RoutingPolicyService
 from obsidian_agent.services.smart_capture_service import SmartCaptureService
 from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
 from obsidian_agent.services.smart_query_service import SmartQueryService
+from obsidian_agent.services.smart_relink_service import SmartRelinkService
 from obsidian_agent.services.teaching_planner_service import TeachingPlannerService
 from obsidian_agent.services.synthesis_service import SynthesisService
 from obsidian_agent.services.weakness_diagnoser_service import WeaknessDiagnoserService
@@ -65,6 +66,7 @@ class AppContainer:
     smart_capture_service: SmartCaptureService
     smart_node_pack_service: SmartNodePackService
     smart_query_service: SmartQueryService
+    smart_relink_service: SmartRelinkService
     teaching_planner_service: TeachingPlannerService
 
 
@@ -182,6 +184,11 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         context_compressor=ContextCompressorService(routing_policy),
     )
     smart_query_service = SmartQueryService(smart_node_pack_service)
+    smart_relink_service = SmartRelinkService(
+        settings=settings,
+        smart_node_pack_service=smart_node_pack_service,
+        review_service=review_service,
+    )
     teaching_planner_service = TeachingPlannerService(
         smart_node_pack_service=smart_node_pack_service,
         routing_policy=routing_policy,
@@ -204,6 +211,7 @@ def build_container(settings: Settings | None = None) -> AppContainer:
         smart_capture_service=smart_capture_service,
         smart_node_pack_service=smart_node_pack_service,
         smart_query_service=smart_query_service,
+        smart_relink_service=smart_relink_service,
         teaching_planner_service=teaching_planner_service,
     )
 

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -255,3 +255,19 @@ class TeachingPackResponse(BaseModel):
     sections: list[TeachingSection] = Field(default_factory=list)
     drills: list[str] = Field(default_factory=list)
     markdown: str
+
+
+class SmartRelinkRequest(BaseModel):
+    node_key: str = Field(min_length=3)
+    top_k: int = Field(default=5, ge=1, le=10)
+    create_review: bool = True
+    dry_run: bool = True
+
+
+class SmartRelinkResponse(BaseModel):
+    pack: RelationPack
+    related_section_markdown: str
+    stored_edges: int = 0
+    review_id: int | None = None
+    proposal_path: str | None = None
+    action_preview: ActionPreview | None = None

--- a/src/obsidian_agent/services/smart_relink_service.py
+++ b/src/obsidian_agent/services/smart_relink_service.py
@@ -1,0 +1,86 @@
+"""Rebuild smart relations and prepare review-safe note updates."""
+
+from __future__ import annotations
+
+from obsidian_agent.config import Settings
+from obsidian_agent.domain.enums import ProposalType, RiskLevel
+from obsidian_agent.domain.schemas import ActionPreview, ReviewProposal, SmartRelinkRequest, SmartRelinkResponse
+from obsidian_agent.services.review_service import ReviewService
+from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
+
+
+class SmartRelinkService:
+    """Refresh related-node suggestions for an existing smart node."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        smart_node_pack_service: SmartNodePackService,
+        review_service: ReviewService,
+    ) -> None:
+        self.settings = settings
+        self.smart_node_pack_service = smart_node_pack_service
+        self.review_service = review_service
+
+    async def relink(self, request: SmartRelinkRequest) -> SmartRelinkResponse:
+        pack_response = await self.smart_node_pack_service.build_node_pack(
+            node_key=request.node_key,
+            top_k=request.top_k,
+        )
+        pack = pack_response.pack
+        if not pack.anchor.note_path:
+            raise ValueError(f"Knowledge node is missing note_path: {request.node_key}")
+        related_section_markdown = self._render_related_section(pack_response.pack)
+        preview = ActionPreview(
+            dry_run=True,
+            action="smart_relink_review",
+            target_path=pack.anchor.note_path,
+            details={
+                "create_review": request.create_review,
+                "top_k": request.top_k,
+                "stored_edges": pack_response.stored_edges,
+            },
+        )
+        if request.dry_run or self.settings.dry_run or not request.create_review:
+            return SmartRelinkResponse(
+                pack=pack,
+                related_section_markdown=related_section_markdown,
+                stored_edges=pack_response.stored_edges,
+                action_preview=preview,
+            )
+
+        proposal = ReviewProposal(
+            proposal_type=ProposalType.APPEND_CANDIDATE,
+            risk_level=RiskLevel.MEDIUM,
+            title=f"Refresh related nodes for {pack.anchor.title}",
+            source_note_path=pack.anchor.note_path,
+            target_note_path=pack.anchor.note_path,
+            rationale=pack.summary or f"Refresh relation links for {pack.anchor.title}.",
+            suggested_patch=related_section_markdown,
+            related_links=[node.note_path for node in pack.related_nodes if node.note_path],
+        )
+        review_id, proposal_path = await self.review_service.create_review_item(proposal)
+        return SmartRelinkResponse(
+            pack=pack,
+            related_section_markdown=related_section_markdown,
+            stored_edges=pack_response.stored_edges,
+            review_id=review_id,
+            proposal_path=proposal_path,
+        )
+
+    def _render_related_section(self, pack) -> str:
+        lines: list[str] = []
+        related_by_key = {node.node_key: node for node in pack.related_nodes}
+        for edge in pack.edges:
+            node = related_by_key.get(edge.to_node_key)
+            target = edge.to_node_key
+            if node and node.note_path:
+                target = f"[[{node.note_path}]]"
+            elif node:
+                target = node.title
+            lines.append(
+                f"- {target}: {edge.relation_type.value} ({edge.confidence:.2f}) - {edge.reason}"
+            )
+        if not lines:
+            lines.append("- No strong related-node suggestions were found in this pass.")
+        return "\n".join(lines)

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -63,6 +63,7 @@ const translations = {
     nodePackPlaceholder: "输入 node_key，例如 error/sizeof-vs-strlen",
     runNodePack: "生成 Node Pack",
     runTeachPack: "生成 Teaching Pack",
+    runRelink: "生成 Relink Review",
     search: "搜索",
     searchPlaceholder: "搜索笔记",
     runSearch: "执行搜索",
@@ -91,6 +92,7 @@ const translations = {
     smartCaptureComplete: "错题分析完成",
     nodePackComplete: "Node Pack 已生成",
     teachPackComplete: "Teaching Pack 已生成",
+    relinkComplete: "Relink Review 已生成",
     startupError: "启动错误",
     consoleCleared: "控制台已清空。",
     maintenancePrefix: "维护结果",
@@ -157,6 +159,7 @@ const translations = {
     nodePackPlaceholder: "Enter a node_key such as error/sizeof-vs-strlen",
     runNodePack: "Build Node Pack",
     runTeachPack: "Build Teaching Pack",
+    runRelink: "Build Relink Review",
     search: "Search",
     searchPlaceholder: "Search notes",
     runSearch: "Run Search",
@@ -185,6 +188,7 @@ const translations = {
     smartCaptureComplete: "Smart error capture complete",
     nodePackComplete: "Node pack generated",
     teachPackComplete: "Teaching pack generated",
+    relinkComplete: "Relink review generated",
     startupError: "Startup error",
     consoleCleared: "Console cleared.",
     maintenancePrefix: "Maintenance",
@@ -335,6 +339,9 @@ function renderSmartResult(payload) {
     : (payload.overview || (payload.pack ? payload.pack.anchor.summary : ""));
   const listHtml = weaknesses || teachingSections || relations || drills || "<li>-</li>";
   const markdown = payload.markdown ? `<pre class="console-output">${payload.markdown}</pre>` : "";
+  const reviewMeta = payload.review_id
+    ? `<small>review #${payload.review_id}: ${payload.proposal_path || ""}</small>`
+    : "";
   target.innerHTML = `
     <article class="result-card">
       <strong>${title}</strong>
@@ -342,6 +349,7 @@ function renderSmartResult(payload) {
       <div>${secondary}</div>
       <ul>${listHtml}</ul>
       ${preview}
+      ${reviewMeta}
       ${markdown}
     </article>
   `;
@@ -468,6 +476,20 @@ document.getElementById("teachSubmit").addEventListener("click", async () => {
   });
   renderSmartResult(payload);
   logResult(t("teachPackComplete"), payload);
+});
+
+document.getElementById("relinkSubmit").addEventListener("click", async () => {
+  const payload = await api("/smart/relink", {
+    method: "POST",
+    body: JSON.stringify({
+      node_key: document.getElementById("nodePackKey").value,
+      top_k: 5,
+      create_review: true,
+      dry_run: false,
+    }),
+  });
+  renderSmartResult(payload);
+  logResult(t("relinkComplete"), payload);
 });
 
 document.getElementById("searchSubmit").addEventListener("click", async () => {

--- a/src/obsidian_agent/ui/index.html
+++ b/src/obsidian_agent/ui/index.html
@@ -125,6 +125,7 @@
               <button id="nodePackSubmit" class="secondary-button" data-i18n="runNodePack">生成 Node Pack</button>
             </div>
             <button id="teachSubmit" class="secondary-button" data-i18n="runTeachPack">生成 Teaching Pack</button>
+            <button id="relinkSubmit" class="secondary-button" data-i18n="runRelink">生成 Relink Review</button>
             <div id="smartResults" class="result-list"></div>
           </div>
         </section>

--- a/tests/integration/test_smart_relink.py
+++ b/tests/integration/test_smart_relink.py
@@ -1,0 +1,111 @@
+from fastapi.testclient import TestClient
+
+from obsidian_agent.app import create_app
+from obsidian_agent.config import Settings
+from obsidian_agent.test_support import make_test_dir
+
+
+def test_smart_relink_dry_run_returns_preview() -> None:
+    root = make_test_dir("smart_relink_preview")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "pointer decay",
+            "prompt": "I thought array parameters stayed arrays inside a function.",
+            "code": 'void f(int arr[10]) { printf("%zu", sizeof(arr)); }',
+            "user_analysis": "I expected the array length to survive parameter passing.",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "pointer confusion",
+            "prompt": "I assumed arr and &arr had the same type.",
+            "code": "int arr[4]; int *p = arr; int (*q)[4] = &arr;",
+            "user_analysis": "I collapsed array and pointer semantics together.",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    response = client.post(
+        "/smart/relink",
+        json={
+            "node_key": first.json()["node"]["node_key"],
+            "top_k": 5,
+            "create_review": True,
+            "dry_run": True,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["action_preview"]["dry_run"] is True
+    assert payload["review_id"] is None
+    assert payload["related_section_markdown"].startswith("- ")
+
+
+def test_smart_relink_creates_review_item() -> None:
+    root = make_test_dir("smart_relink_review")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "sizeof vs strlen",
+            "prompt": "I treated sizeof(arr) as the string length.",
+            "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
+            "user_analysis": "I assumed sizeof returned visible characters only.",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "strlen terminator confusion",
+            "prompt": "I expected strlen to count the null terminator.",
+            "code": 'char arr[] = "abc"; printf("%zu", strlen(arr));',
+            "user_analysis": "I blurred string length and storage size.",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    response = client.post(
+        "/smart/relink",
+        json={
+            "node_key": first.json()["node"]["node_key"],
+            "top_k": 5,
+            "create_review": True,
+            "dry_run": False,
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["review_id"] is not None
+    assert payload["proposal_path"]
+
+    pending = client.get("/review/pending")
+    assert pending.status_code == 200
+    items = pending.json()["items"]
+    assert any(item["id"] == payload["review_id"] for item in items)


### PR DESCRIPTION
# Summary
- add POST /smart/relink to rebuild relation packs for an existing smart node
- return dry-run previews for related-section updates and create review items instead of mutating notes directly
- extend the dashboard and walkthrough for relink review generation

# Risk
- touches smart routing, review generation, and dashboard actions
- review creation reuses the existing review queue path instead of direct note mutation

# Test Evidence
- ruff check src tests scripts --select F,E9,B
- python -m compileall src scripts tests
- pytest tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py tests/integration/test_smart_relink.py tests/integration/test_ui_routes.py tests/unit/test_app.py -q --basetemp data/test_runs/pytest_phase26_exec1
- real Ollama smoke: POST /smart/relink with Qwen14B-fixed:latest returned 200 and created a review note

# Rollback Plan
- Revert the squash merge commit from this PR.
