### PR TITLE
feat: implement issue #28 supporting node writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ python -m compileall src scripts
 - Prompt assets live under `src/obsidian_agent/prompts/` and are tracked by `manifest.json`.
 - The built-in control panel is served from `/` and `/ui`.
 - The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, create relink reviews, search notes, inspect review items, and run maintenance jobs.
+- Smart error capture now writes an `ErrorNode` plus deduplicated supporting `ConceptNode` and `PitfallNode` notes, and records edges to them.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -61,6 +61,7 @@ curl -X POST http://127.0.0.1:8000/smart/error-capture ^
 ```
 
 This creates an Error Node note under the configured smart error folder and records a local `knowledge_nodes` / `error_occurrences` entry.
+The same call now also creates or reuses supporting Concept and Pitfall nodes under the smart nodes folder.
 
 To preview mined relations around that node:
 

--- a/src/obsidian_agent/app.py
+++ b/src/obsidian_agent/app.py
@@ -176,6 +176,7 @@ def build_container(settings: Settings | None = None) -> AppContainer:
             session_factory=session_factory,
             obsidian_service=obsidian_service,
             error_template_path=_template_path("error_node.md.tmpl"),
+            smart_node_template_path=_template_path("smart_node.md.tmpl"),
         ),
     )
     smart_node_pack_service = SmartNodePackService(

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -221,6 +221,7 @@ class SmartErrorCaptureResponse(BaseModel):
     node: KnowledgeNodeSchema
     related_nodes: list[KnowledgeNodeSchema] = Field(default_factory=list)
     action_preview: ActionPreview | None = None
+    stored_edges: int = 0
 
 
 class NodePackRequest(BaseModel):

--- a/src/obsidian_agent/prompts/tasks/smart_node.md.tmpl
+++ b/src/obsidian_agent/prompts/tasks/smart_node.md.tmpl
@@ -1,0 +1,16 @@
+# {{title}}
+
+## Summary
+{{summary}}
+
+## Node Type
+{{node_type}}
+
+## Practice Focus
+{{practice_focus}}
+
+## Related Concepts
+{{related_concepts}}
+
+## Evidence
+{{evidence}}

--- a/src/obsidian_agent/services/node_writer_service.py
+++ b/src/obsidian_agent/services/node_writer_service.py
@@ -2,20 +2,33 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from sqlalchemy.orm import sessionmaker
 
-from obsidian_agent.domain.enums import KnowledgeNodeType, NoteKind, NoteStatus, SourceType
+from obsidian_agent.domain.enums import (
+    KnowledgeNodeType,
+    KnowledgeRelationType,
+    NoteKind,
+    NoteStatus,
+    SourceType,
+)
 from obsidian_agent.domain.schemas import (
+    ActionPreview,
     ErrorCaptureRequest,
     ErrorObject,
     FrontmatterSchema,
+    KnowledgeEdgeSchema,
     KnowledgeNodeSchema,
     WeaknessObject,
 )
 from obsidian_agent.services.obsidian_service import ObsidianService
-from obsidian_agent.storage.repositories import ErrorOccurrenceRepository, KnowledgeNodeRepository
+from obsidian_agent.storage.repositories import (
+    ErrorOccurrenceRepository,
+    KnowledgeEdgeRepository,
+    KnowledgeNodeRepository,
+)
 from obsidian_agent.utils.markdown import render_template
 from obsidian_agent.utils.slugify import slugify
 from obsidian_agent.utils.time import compact_timestamp, now_utc
@@ -29,21 +42,23 @@ class NodeWriterService:
         session_factory: sessionmaker,
         obsidian_service: ObsidianService,
         error_template_path: Path,
+        smart_node_template_path: Path,
     ) -> None:
         self.session_factory = session_factory
         self.obsidian_service = obsidian_service
         self.error_template_path = error_template_path
+        self.smart_node_template_path = smart_node_template_path
 
-    async def write_error_node(
+    async def write_error_bundle(
         self,
         request: ErrorCaptureRequest,
         error: ErrorObject,
         weaknesses: list[WeaknessObject],
-    ) -> tuple[KnowledgeNodeSchema, object | None]:
+    ) -> tuple[KnowledgeNodeSchema, list[KnowledgeNodeSchema], ActionPreview | None, int]:
         node_key = f"error/{slugify(error.error_signature)}"
         existing_node = self._load_existing_node(node_key)
         note_path = existing_node.note_path if existing_node else None
-        action_preview = None
+        action_previews: list[ActionPreview] = []
         if not note_path:
             frontmatter = FrontmatterSchema(
                 id=compact_timestamp(),
@@ -82,7 +97,7 @@ class NodeWriterService:
             )
             if hasattr(write_result, "model_dump"):
                 note_path = write_result.target_path
-                action_preview = write_result
+                action_previews.append(write_result)
             else:
                 note_path = write_result
         node = KnowledgeNodeSchema(
@@ -101,6 +116,8 @@ class NodeWriterService:
                 "weaknesses": [item.model_dump(mode="json") for item in weaknesses],
             },
         )
+        supporting_nodes = self._build_supporting_nodes(error, weaknesses, note_path)
+        persisted_supporting_nodes = await self._upsert_supporting_nodes(supporting_nodes, action_previews)
         with self.session_factory() as session:
             node_repo = KnowledgeNodeRepository(session)
             stored = node_repo.upsert(node)
@@ -111,7 +128,28 @@ class NodeWriterService:
                 node_id=stored.id,
                 source_note_path=node.note_path,
             )
-        return node, action_preview
+            edge_repo = KnowledgeEdgeRepository(session)
+            stored_edges = edge_repo.create_if_missing_batch(
+                from_node_id=stored.id,
+                edges=self._build_supporting_edges(stored.node_key, persisted_supporting_nodes, error),
+                node_ids_by_key={
+                    item.node_key: item.id
+                    for item in node_repo.list_all()
+                    if item.id is not None
+                },
+            )
+        action_preview = None
+        if action_previews:
+            action_preview = ActionPreview(
+                dry_run=True,
+                action="write_error_bundle",
+                target_path=node.note_path or "",
+                details={
+                    "generated_paths": [item.target_path for item in action_previews],
+                    "generated_count": len(action_previews),
+                },
+            )
+        return node, persisted_supporting_nodes, action_preview, len(stored_edges)
 
     def _load_existing_node(self, node_key: str) -> KnowledgeNodeSchema | None:
         with self.session_factory() as session:
@@ -127,8 +165,8 @@ class NodeWriterService:
                 summary=entity.summary,
                 note_path=entity.note_path,
                 source_note_path=entity.source_note_path,
-                tags=[],
-                metadata={},
+                tags=json.loads(entity.tags_json or "[]"),
+                metadata=json.loads(entity.metadata_json or "{}"),
             )
 
     def _compose_raw_input(self, request: ErrorCaptureRequest) -> str:
@@ -137,3 +175,181 @@ class NodeWriterService:
             f"Code:\n{request.code}\n\n"
             f"Analysis:\n{request.user_analysis}\n"
         ).strip()
+
+    def _build_supporting_nodes(
+        self,
+        error: ErrorObject,
+        weaknesses: list[WeaknessObject],
+        source_note_path: str | None,
+    ) -> list[KnowledgeNodeSchema]:
+        nodes: list[KnowledgeNodeSchema] = []
+        concept_keys: set[str] = set()
+        for weakness in weaknesses:
+            for concept in weakness.related_concepts[:2]:
+                key = f"concept/{slugify(concept)}"
+                if key in concept_keys:
+                    continue
+                concept_keys.add(key)
+                nodes.append(
+                    KnowledgeNodeSchema(
+                        node_key=key,
+                        node_type=KnowledgeNodeType.CONCEPT,
+                        title=concept.replace("-", " ").title(),
+                        summary=weakness.summary,
+                        note_path=None,
+                        source_note_path=source_note_path,
+                        tags=["concept", error.language, *error.tags[:2]],
+                        metadata={
+                            "practice_focus": weakness.recommended_practice,
+                            "related_concepts": weakness.related_concepts,
+                            "derived_from_error": error.error_signature,
+                        },
+                    )
+                )
+        pitfall_key = f"pitfall/{slugify(error.error_signature)}"
+        nodes.append(
+            KnowledgeNodeSchema(
+                node_key=pitfall_key,
+                node_type=KnowledgeNodeType.PITFALL,
+                title=f"Pitfall: {error.title}",
+                summary=error.incorrect_assumption,
+                note_path=None,
+                source_note_path=source_note_path,
+                tags=["pitfall", error.language, *error.tags[:2]],
+                metadata={
+                    "practice_focus": error.root_cause,
+                    "related_concepts": error.related_concepts,
+                    "derived_from_error": error.error_signature,
+                    "evidence": error.evidence,
+                },
+            )
+        )
+        return nodes
+
+    async def _upsert_supporting_nodes(
+        self,
+        nodes: list[KnowledgeNodeSchema],
+        action_previews: list[ActionPreview],
+    ) -> list[KnowledgeNodeSchema]:
+        persisted: list[KnowledgeNodeSchema] = []
+        for node in nodes:
+            existing = self._load_existing_node(node.node_key)
+            note_path = existing.note_path if existing else None
+            merged_tags = sorted({*(existing.tags if existing else []), *node.tags})
+            merged_metadata = dict(existing.metadata if existing else {})
+            merged_metadata.update(node.metadata)
+            if not note_path:
+                body = render_template(
+                    self.smart_node_template_path,
+                    {
+                        "title": node.title,
+                        "summary": node.summary,
+                        "node_type": node.node_type.value,
+                        "practice_focus": str(merged_metadata.get("practice_focus", "-")),
+                        "related_concepts": "\n".join(
+                            f"- {item}" for item in merged_metadata.get("related_concepts", [])
+                        )
+                        or "-",
+                        "evidence": "\n".join(
+                            f"- {item}" for item in merged_metadata.get("evidence", [])
+                        )
+                        or "-",
+                    },
+                )
+                frontmatter = FrontmatterSchema(
+                    id=compact_timestamp(),
+                    kind=self._note_kind_for_node(node.node_type),
+                    status=NoteStatus.DRAFT,
+                    source_type=SourceType.MANUAL,
+                    source_ref=node.source_note_path or "",
+                    created_at=now_utc(),
+                    updated_at=now_utc(),
+                    tags=merged_tags,
+                    entities=[],
+                    topics=[str(item) for item in merged_metadata.get("related_concepts", [])],
+                    confidence=0.6,
+                    review_required=False,
+                )
+                write_result = await self.obsidian_service.create_note(
+                    folder=self.obsidian_service.settings.smart_nodes_folder,
+                    title=node.title,
+                    frontmatter=frontmatter.model_dump(mode="json"),
+                    body=body,
+                )
+                if hasattr(write_result, "model_dump"):
+                    note_path = write_result.target_path
+                    action_previews.append(write_result)
+                else:
+                    note_path = write_result
+            summary = node.summary
+            if existing and len(existing.summary) > len(summary):
+                summary = existing.summary
+            persisted.append(
+                KnowledgeNodeSchema(
+                    id=existing.id if existing else None,
+                    node_key=node.node_key,
+                    node_type=node.node_type,
+                    title=existing.title if existing else node.title,
+                    summary=summary,
+                    note_path=note_path,
+                    source_note_path=node.source_note_path,
+                    tags=merged_tags,
+                    metadata=merged_metadata,
+                )
+            )
+        with self.session_factory() as session:
+            repo = KnowledgeNodeRepository(session)
+            stored_nodes = [repo.upsert(node) for node in persisted]
+        return [
+            KnowledgeNodeSchema(
+                id=item.id,
+                node_key=item.node_key,
+                node_type=KnowledgeNodeType(item.node_type),
+                title=item.title,
+                summary=item.summary,
+                note_path=item.note_path,
+                source_note_path=item.source_note_path,
+                tags=json.loads(item.tags_json or "[]"),
+                metadata=json.loads(item.metadata_json or "{}"),
+            )
+            for item in stored_nodes
+        ]
+
+    def _build_supporting_edges(
+        self,
+        error_node_key: str,
+        nodes: list[KnowledgeNodeSchema],
+        error: ErrorObject,
+    ) -> list[KnowledgeEdgeSchema]:
+        edges: list[KnowledgeEdgeSchema] = []
+        for node in nodes:
+            relation_type = (
+                KnowledgeRelationType.REVEALS_GAP_IN
+                if node.node_type == KnowledgeNodeType.CONCEPT
+                else KnowledgeRelationType.COMMONLY_CONFUSED_WITH
+            )
+            reason = (
+                f"{error.title} reveals a gap in {node.title}."
+                if node.node_type == KnowledgeNodeType.CONCEPT
+                else error.incorrect_assumption
+            )
+            edges.append(
+                KnowledgeEdgeSchema(
+                    from_node_key=error_node_key,
+                    to_node_key=node.node_key,
+                    relation_type=relation_type,
+                    reason=reason,
+                    confidence=max(0.55, error.confidence),
+                )
+            )
+        return edges
+
+    @staticmethod
+    def _note_kind_for_node(node_type: KnowledgeNodeType) -> NoteKind:
+        mapping = {
+            KnowledgeNodeType.CONCEPT: NoteKind.CONCEPT,
+            KnowledgeNodeType.PITFALL: NoteKind.PITFALL,
+            KnowledgeNodeType.CONTRAST: NoteKind.CONTRAST,
+            KnowledgeNodeType.ERROR: NoteKind.ERROR,
+        }
+        return mapping[node_type]

--- a/src/obsidian_agent/services/smart_capture_service.py
+++ b/src/obsidian_agent/services/smart_capture_service.py
@@ -24,11 +24,16 @@ class SmartCaptureService:
     async def capture_error(self, payload: ErrorCaptureRequest) -> SmartErrorCaptureResponse:
         error = await self.error_extractor.extract(payload)
         weaknesses = await self.weakness_diagnoser.diagnose(error)
-        node, action_preview = await self.node_writer.write_error_node(payload, error, weaknesses)
+        node, related_nodes, action_preview, stored_edges = await self.node_writer.write_error_bundle(
+            payload,
+            error,
+            weaknesses,
+        )
         return SmartErrorCaptureResponse(
             error=error,
             weaknesses=weaknesses,
             node=node,
-            related_nodes=[],
-            action_preview=action_preview if hasattr(action_preview, "model_dump") else None,
+            related_nodes=related_nodes,
+            action_preview=action_preview,
+            stored_edges=stored_edges,
         )

--- a/src/obsidian_agent/storage/repositories.py
+++ b/src/obsidian_agent/storage/repositories.py
@@ -281,6 +281,45 @@ class KnowledgeEdgeRepository:
             self.session.refresh(entity)
         return created
 
+    def create_if_missing_batch(
+        self,
+        from_node_id: int | None,
+        edges: list[KnowledgeEdgeSchema],
+        node_ids_by_key: dict[str, int],
+    ) -> list[KnowledgeEdge]:
+        if from_node_id is None:
+            return []
+        existing = list(
+            self.session.scalars(select(KnowledgeEdge).where(KnowledgeEdge.from_node_id == from_node_id)).all()
+        )
+        existing_keys = {
+            (row.to_node_id, row.relation_type)
+            for row in existing
+            if row.to_node_id is not None
+        }
+        created: list[KnowledgeEdge] = []
+        for edge in edges:
+            target_id = node_ids_by_key.get(edge.to_node_key)
+            if target_id is None:
+                continue
+            key = (target_id, edge.relation_type.value)
+            if key in existing_keys:
+                continue
+            entity = KnowledgeEdge(
+                from_node_id=from_node_id,
+                to_node_id=target_id,
+                relation_type=edge.relation_type.value,
+                reason=edge.reason,
+                confidence=edge.confidence,
+            )
+            self.session.add(entity)
+            created.append(entity)
+            existing_keys.add(key)
+        self.session.commit()
+        for entity in created:
+            self.session.refresh(entity)
+        return created
+
 
 class ErrorOccurrenceRepository:
     """Captured error occurrences repository."""

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -320,6 +320,9 @@ function renderSmartResult(payload) {
   const weaknesses = (payload.weaknesses || [])
     .map((item) => `<li>${item.name}: ${item.summary}</li>`)
     .join("");
+  const generatedNodes = (payload.related_nodes || [])
+    .map((item) => `<li>${item.node_type}: ${item.title}</li>`)
+    .join("");
   const relations = (((payload.pack || {}).edges) || [])
     .map((item) => `<li>${item.relation_type} -> ${item.to_node_key} (${item.confidence})</li>`)
     .join("");
@@ -337,11 +340,12 @@ function renderSmartResult(payload) {
   const secondary = payload.error
     ? payload.error.root_cause
     : (payload.overview || (payload.pack ? payload.pack.anchor.summary : ""));
-  const listHtml = weaknesses || teachingSections || relations || drills || "<li>-</li>";
+  const listHtml = [weaknesses, generatedNodes, teachingSections, relations, drills].filter((item) => item).join("") || "<li>-</li>";
   const markdown = payload.markdown ? `<pre class="console-output">${payload.markdown}</pre>` : "";
   const reviewMeta = payload.review_id
     ? `<small>review #${payload.review_id}: ${payload.proposal_path || ""}</small>`
     : "";
+  const edgeMeta = payload.stored_edges ? `<small>stored edges: ${payload.stored_edges}</small>` : "";
   target.innerHTML = `
     <article class="result-card">
       <strong>${title}</strong>
@@ -349,6 +353,7 @@ function renderSmartResult(payload) {
       <div>${secondary}</div>
       <ul>${listHtml}</ul>
       ${preview}
+      ${edgeMeta}
       ${reviewMeta}
       ${markdown}
     </article>

--- a/tests/integration/test_smart_capture.py
+++ b/tests/integration/test_smart_capture.py
@@ -2,11 +2,11 @@ from fastapi.testclient import TestClient
 
 from obsidian_agent.app import build_container, create_app
 from obsidian_agent.config import Settings
-from obsidian_agent.domain.models import ErrorOccurrence, KnowledgeNode
+from obsidian_agent.domain.models import ErrorOccurrence, KnowledgeEdge, KnowledgeNode
 from obsidian_agent.test_support import make_test_dir
 
 
-def test_smart_error_capture_creates_error_node_and_db_records() -> None:
+def test_smart_error_capture_creates_error_and_supporting_nodes() -> None:
     root = make_test_dir("smart_error_capture")
     settings = Settings(
         _env_file=None,
@@ -22,10 +22,10 @@ def test_smart_error_capture_creates_error_node_and_db_records() -> None:
     response = client.post(
         "/smart/error-capture",
         json={
-            "title": "sizeof 和 strlen 混淆",
-            "prompt": "我把 sizeof(arr) 当成字符串长度使用，结果输出包含结尾空字符。",
+            "title": "sizeof vs strlen confusion",
+            "prompt": "I treated sizeof(arr) as the visible string length in C.",
             "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
-            "user_analysis": "我以为 sizeof 会返回可见字符数量。",
+            "user_analysis": "I assumed sizeof returned only visible characters.",
             "language": "c",
             "source_ref": "manual/c-sizeof",
         },
@@ -35,18 +35,69 @@ def test_smart_error_capture_creates_error_node_and_db_records() -> None:
     payload = response.json()
     assert payload["error"]["error_signature"] == "sizeof-vs-strlen"
     assert payload["node"]["node_type"] == "error"
+    assert payload["related_nodes"]
+    assert payload["stored_edges"] >= 1
+
     note_path = payload["node"]["note_path"]
     assert note_path.startswith("21 Errors/")
     created = (settings.vault_root / note_path).read_text(encoding="utf-8")
-    assert "# sizeof 和 strlen 混淆" in created
+    assert "# sizeof vs strlen confusion" in created
     assert "Incorrect Assumption" in created
 
     container = build_container(settings)
     with container.session_factory() as session:
-        node = session.query(KnowledgeNode).one()
+        nodes = session.query(KnowledgeNode).all()
+        edges = session.query(KnowledgeEdge).all()
         occurrence = session.query(ErrorOccurrence).one()
-        assert node.node_key == "error/sizeof-vs-strlen"
+        assert any(node.node_key == "error/sizeof-vs-strlen" for node in nodes)
+        assert any(node.node_type == "concept" for node in nodes)
+        assert any(node.node_type == "pitfall" for node in nodes)
+        assert edges
         assert occurrence.error_signature == "sizeof-vs-strlen"
+
+
+def test_smart_error_capture_reuses_existing_supporting_nodes() -> None:
+    root = make_test_dir("smart_error_capture_novelty")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "pointer and array decay",
+            "prompt": "I thought array parameters stayed arrays inside a function.",
+            "code": 'void f(int arr[10]) { printf("%zu", sizeof(arr)); }',
+            "user_analysis": "I expected the array length to survive parameter passing.",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "parameter decay again",
+            "prompt": "I still confuse array parameters with full arrays in C.",
+            "code": 'void g(int arr[3]) { printf("%zu", sizeof(arr)); }',
+            "user_analysis": "I repeated the same misunderstanding about array decay.",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    container = build_container(settings)
+    with container.session_factory() as session:
+        nodes = session.query(KnowledgeNode).all()
+        concept_keys = [node.node_key for node in nodes if node.node_type == "concept"]
+        pitfall_keys = [node.node_key for node in nodes if node.node_type == "pitfall"]
+        assert len(concept_keys) == len(set(concept_keys))
+        assert len(pitfall_keys) == len(set(pitfall_keys))
 
 
 def test_smart_node_pack_builds_relations_between_related_errors() -> None:
@@ -64,10 +115,10 @@ def test_smart_node_pack_builds_relations_between_related_errors() -> None:
     first = client.post(
         "/smart/error-capture",
         json={
-            "title": "sizeof 和 strlen 混淆",
-            "prompt": "我把 sizeof(arr) 当成字符串长度使用。",
+            "title": "sizeof vs strlen confusion",
+            "prompt": "I treated sizeof(arr) as the visible string length.",
             "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
-            "user_analysis": "我以为 sizeof 会返回可见字符数量。",
+            "user_analysis": "I assumed sizeof only tracked visible characters.",
             "language": "c",
         },
     )
@@ -75,10 +126,10 @@ def test_smart_node_pack_builds_relations_between_related_errors() -> None:
     second = client.post(
         "/smart/error-capture",
         json={
-            "title": "strlen 不统计终止符",
-            "prompt": "我没有意识到 strlen 不会包含结尾的空字符。",
+            "title": "strlen terminator confusion",
+            "prompt": "I expected strlen to count the null terminator.",
             "code": 'char arr[] = "abc"; printf("%zu", strlen(arr));',
-            "user_analysis": "我把 strlen 和内存大小混成一类了。",
+            "user_analysis": "I mixed up string length and storage size.",
             "language": "c",
         },
     )


### PR DESCRIPTION
# Summary
- extend smart error capture to create deduplicated Concept and Pitfall nodes alongside the Error node
- record supporting edges from the Error node to generated smart nodes
- surface generated nodes and edge counts in the dashboard response

# Risk
- touches node writing, knowledge edge persistence, and smart capture response shape
- novelty filtering is key-based and intentionally conservative in this iteration

# Test Evidence
- ruff check src tests scripts --select F,E9,B
- python -m compileall src scripts tests
- pytest tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py tests/integration/test_smart_relink.py tests/integration/test_ui_routes.py tests/unit/test_app.py -q --basetemp data/test_runs/pytest_phase28_exec1
- real Ollama smoke: POST /smart/error-capture with Qwen14B-fixed:latest returned 200 and produced concept/pitfall nodes

# Rollback Plan
- Revert the squash merge commit from this PR.
