### PR TITLE
feat: implement issue #30 contrast nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ python -m compileall src scripts
 - Prompt assets live under `src/obsidian_agent/prompts/` and are tracked by `manifest.json`.
 - The built-in control panel is served from `/` and `/ui`.
 - The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, create relink reviews, search notes, inspect review items, and run maintenance jobs.
-- Smart error capture now writes an `ErrorNode` plus deduplicated supporting `ConceptNode` and `PitfallNode` notes, and records edges to them.
+- Smart error capture creates deduplicated support nodes for `concept`, `pitfall`, and `contrast` when the input suggests them.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -60,8 +60,7 @@ curl -X POST http://127.0.0.1:8000/smart/error-capture ^
   -d "{\"title\":\"sizeof vs strlen\",\"prompt\":\"I treated sizeof(arr) as the string length.\",\"code\":\"char arr[] = \\\"abc\\\"; printf(\\\"%zu\\\", sizeof(arr));\",\"user_analysis\":\"I assumed sizeof returns visible characters.\",\"language\":\"c\"}"
 ```
 
-This creates an Error Node note under the configured smart error folder and records a local `knowledge_nodes` / `error_occurrences` entry.
-The same call now also creates or reuses supporting Concept and Pitfall nodes under the smart nodes folder.
+This creates an Error Node note under the configured smart error folder and records local `knowledge_nodes` / `error_occurrences` entries. When the error implies a comparison or repeated confusion, it also creates or reuses support nodes in the smart nodes folder.
 
 To preview mined relations around that node:
 

--- a/src/obsidian_agent/services/node_writer_service.py
+++ b/src/obsidian_agent/services/node_writer_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from sqlalchemy.orm import sessionmaker
@@ -35,7 +36,7 @@ from obsidian_agent.utils.time import compact_timestamp, now_utc
 
 
 class NodeWriterService:
-    """Persist error nodes and occurrences."""
+    """Persist smart nodes, reuse near-duplicates, and link them together."""
 
     def __init__(
         self,
@@ -55,10 +56,59 @@ class NodeWriterService:
         error: ErrorObject,
         weaknesses: list[WeaknessObject],
     ) -> tuple[KnowledgeNodeSchema, list[KnowledgeNodeSchema], ActionPreview | None, int]:
-        node_key = f"error/{slugify(error.error_signature)}"
-        existing_node = self._load_existing_node(node_key)
-        note_path = existing_node.note_path if existing_node else None
         action_previews: list[ActionPreview] = []
+        error_node = await self._write_or_reuse_error_node(request, error, weaknesses, action_previews)
+        supporting_nodes = await self._write_or_reuse_supporting_nodes(
+            error=error,
+            weaknesses=weaknesses,
+            source_note_path=error_node.note_path,
+            action_previews=action_previews,
+        )
+
+        with self.session_factory() as session:
+            node_repo = KnowledgeNodeRepository(session)
+            error_entity = node_repo.get_by_key(error_node.node_key)
+            if error_entity is None:
+                raise ValueError(f"Stored error node not found: {error_node.node_key}")
+            ErrorOccurrenceRepository(session).create(
+                error=error,
+                raw_input=self._compose_raw_input(request),
+                node_id=error_entity.id,
+                source_note_path=error_node.note_path,
+            )
+            stored_edges = KnowledgeEdgeRepository(session).create_if_missing_batch(
+                from_node_id=error_entity.id,
+                edges=self._build_supporting_edges(error, error_node.node_key, supporting_nodes),
+                node_ids_by_key={
+                    entity.node_key: entity.id
+                    for entity in node_repo.list_all()
+                    if entity.id is not None
+                },
+            )
+
+        preview = None
+        if action_previews:
+            preview = ActionPreview(
+                dry_run=True,
+                action="write_error_bundle",
+                target_path=error_node.note_path or "",
+                details={
+                    "generated_paths": [item.target_path for item in action_previews],
+                    "generated_count": len(action_previews),
+                },
+            )
+        return error_node, supporting_nodes, preview, len(stored_edges)
+
+    async def _write_or_reuse_error_node(
+        self,
+        request: ErrorCaptureRequest,
+        error: ErrorObject,
+        weaknesses: list[WeaknessObject],
+        action_previews: list[ActionPreview],
+    ) -> KnowledgeNodeSchema:
+        node_key = f"error/{slugify(error.error_signature)}"
+        existing = self._load_existing_node(node_key)
+        note_path = existing.note_path if existing else None
         if not note_path:
             frontmatter = FrontmatterSchema(
                 id=compact_timestamp(),
@@ -100,14 +150,16 @@ class NodeWriterService:
                 action_previews.append(write_result)
             else:
                 note_path = write_result
+
         node = KnowledgeNodeSchema(
+            id=existing.id if existing else None,
             node_key=node_key,
             node_type=KnowledgeNodeType.ERROR,
-            title=error.title,
-            summary=error.summary,
+            title=existing.title if existing else error.title,
+            summary=existing.summary if existing and len(existing.summary) >= len(error.summary) else error.summary,
             note_path=note_path,
             source_note_path=request.source_ref or None,
-            tags=error.tags,
+            tags=sorted({*(existing.tags if existing else []), *error.tags}),
             metadata={
                 "language": error.language,
                 "error_signature": error.error_signature,
@@ -116,83 +168,106 @@ class NodeWriterService:
                 "weaknesses": [item.model_dump(mode="json") for item in weaknesses],
             },
         )
-        supporting_nodes = self._build_supporting_nodes(error, weaknesses, note_path)
-        persisted_supporting_nodes = await self._upsert_supporting_nodes(supporting_nodes, action_previews)
         with self.session_factory() as session:
-            node_repo = KnowledgeNodeRepository(session)
-            stored = node_repo.upsert(node)
-            occurrence_repo = ErrorOccurrenceRepository(session)
-            occurrence_repo.create(
-                error=error,
-                raw_input=self._compose_raw_input(request),
-                node_id=stored.id,
-                source_note_path=node.note_path,
-            )
-            edge_repo = KnowledgeEdgeRepository(session)
-            stored_edges = edge_repo.create_if_missing_batch(
-                from_node_id=stored.id,
-                edges=self._build_supporting_edges(stored.node_key, persisted_supporting_nodes, error),
-                node_ids_by_key={
-                    item.node_key: item.id
-                    for item in node_repo.list_all()
-                    if item.id is not None
-                },
-            )
-        action_preview = None
-        if action_previews:
-            action_preview = ActionPreview(
-                dry_run=True,
-                action="write_error_bundle",
-                target_path=node.note_path or "",
-                details={
-                    "generated_paths": [item.target_path for item in action_previews],
-                    "generated_count": len(action_previews),
-                },
-            )
-        return node, persisted_supporting_nodes, action_preview, len(stored_edges)
+            stored = KnowledgeNodeRepository(session).upsert(node)
+        return self._entity_to_schema(stored)
 
-    def _load_existing_node(self, node_key: str) -> KnowledgeNodeSchema | None:
-        with self.session_factory() as session:
-            repo = KnowledgeNodeRepository(session)
-            entity = repo.get_by_key(node_key)
-            if entity is None:
-                return None
-            return KnowledgeNodeSchema(
-                id=entity.id,
-                node_key=entity.node_key,
-                node_type=KnowledgeNodeType(entity.node_type),
-                title=entity.title,
-                summary=entity.summary,
-                note_path=entity.note_path,
-                source_note_path=entity.source_note_path,
-                tags=json.loads(entity.tags_json or "[]"),
-                metadata=json.loads(entity.metadata_json or "{}"),
+    async def _write_or_reuse_supporting_nodes(
+        self,
+        error: ErrorObject,
+        weaknesses: list[WeaknessObject],
+        source_note_path: str | None,
+        action_previews: list[ActionPreview],
+    ) -> list[KnowledgeNodeSchema]:
+        specs = self._build_supporting_specs(error, weaknesses, source_note_path)
+        stored_nodes: list[KnowledgeNodeSchema] = []
+        for spec in specs:
+            reused = self._find_existing_support_node(spec)
+            note_path = reused.note_path if reused else None
+            merged_tags = sorted({*(reused.tags if reused else []), *spec.tags})
+            merged_metadata = dict(reused.metadata if reused else {})
+            merged_metadata.update(spec.metadata)
+            summary = reused.summary if reused and len(reused.summary) >= len(spec.summary) else spec.summary
+            title = reused.title if reused else spec.title
+            node_key = reused.node_key if reused else spec.node_key
+
+            if not note_path:
+                frontmatter = FrontmatterSchema(
+                    id=compact_timestamp(),
+                    kind=self._note_kind_for_node(spec.node_type),
+                    status=NoteStatus.DRAFT,
+                    source_type=SourceType.MANUAL,
+                    source_ref=source_note_path or "",
+                    created_at=now_utc(),
+                    updated_at=now_utc(),
+                    tags=merged_tags,
+                    entities=[],
+                    topics=[str(item) for item in merged_metadata.get("related_concepts", [])],
+                    confidence=0.6,
+                    review_required=False,
+                )
+                body = render_template(
+                    self.smart_node_template_path,
+                    {
+                        "title": title,
+                        "summary": summary,
+                        "node_type": spec.node_type.value,
+                        "practice_focus": str(merged_metadata.get("practice_focus", "-")),
+                        "related_concepts": "\n".join(
+                            f"- {item}" for item in merged_metadata.get("related_concepts", [])
+                        )
+                        or "-",
+                        "evidence": "\n".join(
+                            f"- {item}" for item in merged_metadata.get("evidence", [])
+                        )
+                        or "-",
+                    },
+                )
+                write_result = await self.obsidian_service.create_note(
+                    folder=self.obsidian_service.settings.smart_nodes_folder,
+                    title=title,
+                    frontmatter=frontmatter.model_dump(mode="json"),
+                    body=body,
+                )
+                if hasattr(write_result, "model_dump"):
+                    note_path = write_result.target_path
+                    action_previews.append(write_result)
+                else:
+                    note_path = write_result
+
+            node = KnowledgeNodeSchema(
+                id=reused.id if reused else None,
+                node_key=node_key,
+                node_type=spec.node_type,
+                title=title,
+                summary=summary,
+                note_path=note_path,
+                source_note_path=source_note_path,
+                tags=merged_tags,
+                metadata=merged_metadata,
             )
+            with self.session_factory() as session:
+                stored = KnowledgeNodeRepository(session).upsert(node)
+            stored_nodes.append(self._entity_to_schema(stored))
+        return stored_nodes
 
-    def _compose_raw_input(self, request: ErrorCaptureRequest) -> str:
-        return (
-            f"Prompt:\n{request.prompt}\n\n"
-            f"Code:\n{request.code}\n\n"
-            f"Analysis:\n{request.user_analysis}\n"
-        ).strip()
-
-    def _build_supporting_nodes(
+    def _build_supporting_specs(
         self,
         error: ErrorObject,
         weaknesses: list[WeaknessObject],
         source_note_path: str | None,
     ) -> list[KnowledgeNodeSchema]:
         nodes: list[KnowledgeNodeSchema] = []
-        concept_keys: set[str] = set()
+        concept_seen: set[str] = set()
         for weakness in weaknesses:
             for concept in weakness.related_concepts[:2]:
-                key = f"concept/{slugify(concept)}"
-                if key in concept_keys:
+                node_key = f"concept/{slugify(concept)}"
+                if node_key in concept_seen:
                     continue
-                concept_keys.add(key)
+                concept_seen.add(node_key)
                 nodes.append(
                     KnowledgeNodeSchema(
-                        node_key=key,
+                        node_key=node_key,
                         node_type=KnowledgeNodeType.CONCEPT,
                         title=concept.replace("-", " ").title(),
                         summary=weakness.summary,
@@ -203,13 +278,14 @@ class NodeWriterService:
                             "practice_focus": weakness.recommended_practice,
                             "related_concepts": weakness.related_concepts,
                             "derived_from_error": error.error_signature,
+                            "evidence": error.evidence[:2],
                         },
                     )
                 )
-        pitfall_key = f"pitfall/{slugify(error.error_signature)}"
+
         nodes.append(
             KnowledgeNodeSchema(
-                node_key=pitfall_key,
+                node_key=f"pitfall/{slugify(error.error_signature)}",
                 node_type=KnowledgeNodeType.PITFALL,
                 title=f"Pitfall: {error.title}",
                 summary=error.incorrect_assumption,
@@ -224,115 +300,62 @@ class NodeWriterService:
                 },
             )
         )
-        return nodes
 
-    async def _upsert_supporting_nodes(
-        self,
-        nodes: list[KnowledgeNodeSchema],
-        action_previews: list[ActionPreview],
-    ) -> list[KnowledgeNodeSchema]:
-        persisted: list[KnowledgeNodeSchema] = []
-        for node in nodes:
-            existing = self._load_existing_node(node.node_key)
-            note_path = existing.note_path if existing else None
-            merged_tags = sorted({*(existing.tags if existing else []), *node.tags})
-            merged_metadata = dict(existing.metadata if existing else {})
-            merged_metadata.update(node.metadata)
-            if not note_path:
-                body = render_template(
-                    self.smart_node_template_path,
-                    {
-                        "title": node.title,
-                        "summary": node.summary,
-                        "node_type": node.node_type.value,
-                        "practice_focus": str(merged_metadata.get("practice_focus", "-")),
-                        "related_concepts": "\n".join(
-                            f"- {item}" for item in merged_metadata.get("related_concepts", [])
-                        )
-                        or "-",
-                        "evidence": "\n".join(
-                            f"- {item}" for item in merged_metadata.get("evidence", [])
-                        )
-                        or "-",
+        contrast_title = self._contrast_title(error)
+        if contrast_title:
+            nodes.append(
+                KnowledgeNodeSchema(
+                    node_key=f"contrast/{slugify(contrast_title)}",
+                    node_type=KnowledgeNodeType.CONTRAST,
+                    title=contrast_title,
+                    summary=f"Contrast the commonly confused ideas behind {error.title}.",
+                    note_path=None,
+                    source_note_path=source_note_path,
+                    tags=["contrast", error.language, *error.tags[:2]],
+                    metadata={
+                        "practice_focus": error.incorrect_assumption,
+                        "related_concepts": error.related_concepts,
+                        "derived_from_error": error.error_signature,
+                        "evidence": error.evidence,
                     },
                 )
-                frontmatter = FrontmatterSchema(
-                    id=compact_timestamp(),
-                    kind=self._note_kind_for_node(node.node_type),
-                    status=NoteStatus.DRAFT,
-                    source_type=SourceType.MANUAL,
-                    source_ref=node.source_note_path or "",
-                    created_at=now_utc(),
-                    updated_at=now_utc(),
-                    tags=merged_tags,
-                    entities=[],
-                    topics=[str(item) for item in merged_metadata.get("related_concepts", [])],
-                    confidence=0.6,
-                    review_required=False,
-                )
-                write_result = await self.obsidian_service.create_note(
-                    folder=self.obsidian_service.settings.smart_nodes_folder,
-                    title=node.title,
-                    frontmatter=frontmatter.model_dump(mode="json"),
-                    body=body,
-                )
-                if hasattr(write_result, "model_dump"):
-                    note_path = write_result.target_path
-                    action_previews.append(write_result)
-                else:
-                    note_path = write_result
-            summary = node.summary
-            if existing and len(existing.summary) > len(summary):
-                summary = existing.summary
-            persisted.append(
-                KnowledgeNodeSchema(
-                    id=existing.id if existing else None,
-                    node_key=node.node_key,
-                    node_type=node.node_type,
-                    title=existing.title if existing else node.title,
-                    summary=summary,
-                    note_path=note_path,
-                    source_note_path=node.source_note_path,
-                    tags=merged_tags,
-                    metadata=merged_metadata,
-                )
             )
+        return nodes
+
+    def _find_existing_support_node(self, candidate: KnowledgeNodeSchema) -> KnowledgeNodeSchema | None:
+        direct = self._load_existing_node(candidate.node_key)
+        if direct is not None:
+            return direct
+        normalized_title = self._normalize_text(candidate.title)
+        normalized_summary = self._normalize_text(candidate.summary)
         with self.session_factory() as session:
             repo = KnowledgeNodeRepository(session)
-            stored_nodes = [repo.upsert(node) for node in persisted]
-        return [
-            KnowledgeNodeSchema(
-                id=item.id,
-                node_key=item.node_key,
-                node_type=KnowledgeNodeType(item.node_type),
-                title=item.title,
-                summary=item.summary,
-                note_path=item.note_path,
-                source_note_path=item.source_note_path,
-                tags=json.loads(item.tags_json or "[]"),
-                metadata=json.loads(item.metadata_json or "{}"),
-            )
-            for item in stored_nodes
-        ]
+            for entity in repo.list_all():
+                if entity.node_type != candidate.node_type.value:
+                    continue
+                existing = self._entity_to_schema(entity)
+                if self._normalize_text(existing.title) == normalized_title:
+                    return existing
+                if normalized_summary and self._normalize_text(existing.summary) == normalized_summary:
+                    return existing
+        return None
 
     def _build_supporting_edges(
         self,
+        error: ErrorObject,
         error_node_key: str,
         nodes: list[KnowledgeNodeSchema],
-        error: ErrorObject,
     ) -> list[KnowledgeEdgeSchema]:
         edges: list[KnowledgeEdgeSchema] = []
         for node in nodes:
-            relation_type = (
-                KnowledgeRelationType.REVEALS_GAP_IN
-                if node.node_type == KnowledgeNodeType.CONCEPT
-                else KnowledgeRelationType.COMMONLY_CONFUSED_WITH
-            )
-            reason = (
-                f"{error.title} reveals a gap in {node.title}."
-                if node.node_type == KnowledgeNodeType.CONCEPT
-                else error.incorrect_assumption
-            )
+            relation_type = KnowledgeRelationType.COMMONLY_CONFUSED_WITH
+            reason = error.incorrect_assumption
+            if node.node_type == KnowledgeNodeType.CONCEPT:
+                relation_type = KnowledgeRelationType.REVEALS_GAP_IN
+                reason = f"{error.title} reveals a gap in {node.title}."
+            elif node.node_type == KnowledgeNodeType.CONTRAST:
+                relation_type = KnowledgeRelationType.CONTRASTS_WITH
+                reason = f"{error.title} benefits from contrasting the nearby concepts explicitly."
             edges.append(
                 KnowledgeEdgeSchema(
                     from_node_key=error_node_key,
@@ -344,12 +367,56 @@ class NodeWriterService:
             )
         return edges
 
+    def _load_existing_node(self, node_key: str) -> KnowledgeNodeSchema | None:
+        with self.session_factory() as session:
+            entity = KnowledgeNodeRepository(session).get_by_key(node_key)
+        return self._entity_to_schema(entity) if entity is not None else None
+
+    def _entity_to_schema(self, entity) -> KnowledgeNodeSchema:
+        return KnowledgeNodeSchema(
+            id=entity.id,
+            node_key=entity.node_key,
+            node_type=KnowledgeNodeType(entity.node_type),
+            title=entity.title,
+            summary=entity.summary,
+            note_path=entity.note_path,
+            source_note_path=entity.source_note_path,
+            tags=json.loads(entity.tags_json or "[]"),
+            metadata=json.loads(entity.metadata_json or "{}"),
+        )
+
+    def _compose_raw_input(self, request: ErrorCaptureRequest) -> str:
+        return (
+            f"Prompt:\n{request.prompt}\n\n"
+            f"Code:\n{request.code}\n\n"
+            f"Analysis:\n{request.user_analysis}\n"
+        ).strip()
+
+    def _contrast_title(self, error: ErrorObject) -> str | None:
+        signature = error.error_signature.lower()
+        if "-vs-" in signature:
+            left, right = signature.split("-vs-", maxsplit=1)
+            return f"Contrast: {left.replace('-', ' ')} vs {right.replace('-', ' ')}"
+        concepts = error.related_concepts[:2]
+        if len(concepts) >= 2:
+            return f"Contrast: {concepts[0].replace('-', ' ')} vs {concepts[1].replace('-', ' ')}"
+        if "arr" in error.incorrect_assumption.lower() and "&arr" in " ".join(error.evidence).lower():
+            return "Contrast: arr vs &arr"
+        return None
+
+    def _normalize_text(self, text: str) -> str:
+        lowered = text.lower()
+        lowered = lowered.replace("&", " and ")
+        lowered = re.sub(r"[^a-z0-9]+", " ", lowered)
+        tokens = [token for token in lowered.split() if token not in {"the", "a", "an", "in", "of"}]
+        return " ".join(tokens)
+
     @staticmethod
     def _note_kind_for_node(node_type: KnowledgeNodeType) -> NoteKind:
         mapping = {
-            KnowledgeNodeType.CONCEPT: NoteKind.CONCEPT,
-            KnowledgeNodeType.PITFALL: NoteKind.PITFALL,
-            KnowledgeNodeType.CONTRAST: NoteKind.CONTRAST,
             KnowledgeNodeType.ERROR: NoteKind.ERROR,
+            KnowledgeNodeType.CONCEPT: NoteKind.CONCEPT,
+            KnowledgeNodeType.CONTRAST: NoteKind.CONTRAST,
+            KnowledgeNodeType.PITFALL: NoteKind.PITFALL,
         }
         return mapping[node_type]

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -340,7 +340,8 @@ function renderSmartResult(payload) {
   const secondary = payload.error
     ? payload.error.root_cause
     : (payload.overview || (payload.pack ? payload.pack.anchor.summary : ""));
-  const listHtml = [weaknesses, generatedNodes, teachingSections, relations, drills].filter((item) => item).join("") || "<li>-</li>";
+  const listHtml = [weaknesses, generatedNodes, teachingSections, relations, drills].filter((item) => item).join("")
+    || "<li>-</li>";
   const markdown = payload.markdown ? `<pre class="console-output">${payload.markdown}</pre>` : "";
   const reviewMeta = payload.review_id
     ? `<small>review #${payload.review_id}: ${payload.proposal_path || ""}</small>`

--- a/tests/integration/test_smart_capture.py
+++ b/tests/integration/test_smart_capture.py
@@ -6,7 +6,7 @@ from obsidian_agent.domain.models import ErrorOccurrence, KnowledgeEdge, Knowled
 from obsidian_agent.test_support import make_test_dir
 
 
-def test_smart_error_capture_creates_error_and_supporting_nodes() -> None:
+def test_smart_error_capture_creates_supporting_nodes_and_edges() -> None:
     root = make_test_dir("smart_error_capture")
     settings = Settings(
         _env_file=None,
@@ -16,6 +16,7 @@ def test_smart_error_capture_creates_error_and_supporting_nodes() -> None:
         sqlite_path=root / "db.sqlite3",
         vector_store_path=root / "vectors.json",
         smart_errors_folder="21 Errors",
+        smart_nodes_folder="20 Smart",
     )
     client = TestClient(create_app(settings))
 
@@ -36,13 +37,16 @@ def test_smart_error_capture_creates_error_and_supporting_nodes() -> None:
     assert payload["error"]["error_signature"] == "sizeof-vs-strlen"
     assert payload["node"]["node_type"] == "error"
     assert payload["related_nodes"]
-    assert payload["stored_edges"] >= 1
+    assert payload["stored_edges"] >= 2
+    assert any(item["node_type"] == "contrast" for item in payload["related_nodes"])
 
-    note_path = payload["node"]["note_path"]
-    assert note_path.startswith("21 Errors/")
-    created = (settings.vault_root / note_path).read_text(encoding="utf-8")
-    assert "# sizeof vs strlen confusion" in created
-    assert "Incorrect Assumption" in created
+    error_note_path = payload["node"]["note_path"]
+    assert error_note_path.startswith("21 Errors/")
+    error_note_text = (settings.vault_root / error_note_path).read_text(encoding="utf-8")
+    assert "# sizeof vs strlen confusion" in error_note_text
+
+    support_paths = [item["note_path"] for item in payload["related_nodes"] if item["note_path"]]
+    assert any(path.startswith("20 Smart/") for path in support_paths)
 
     container = build_container(settings)
     with container.session_factory() as session:
@@ -52,11 +56,12 @@ def test_smart_error_capture_creates_error_and_supporting_nodes() -> None:
         assert any(node.node_key == "error/sizeof-vs-strlen" for node in nodes)
         assert any(node.node_type == "concept" for node in nodes)
         assert any(node.node_type == "pitfall" for node in nodes)
+        assert any(node.node_type == "contrast" for node in nodes)
         assert edges
         assert occurrence.error_signature == "sizeof-vs-strlen"
 
 
-def test_smart_error_capture_reuses_existing_supporting_nodes() -> None:
+def test_smart_error_capture_reuses_near_duplicate_supporting_nodes() -> None:
     root = make_test_dir("smart_error_capture_novelty")
     settings = Settings(
         _env_file=None,
@@ -65,6 +70,52 @@ def test_smart_error_capture_reuses_existing_supporting_nodes() -> None:
         sqlite_path=root / "db.sqlite3",
         vector_store_path=root / "vectors.json",
         smart_errors_folder="21 Errors",
+        smart_nodes_folder="20 Smart",
+    )
+    client = TestClient(create_app(settings))
+
+    first = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "sizeof vs strlen confusion",
+            "prompt": "I treated sizeof(arr) as the visible string length.",
+            "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
+            "user_analysis": "I assumed sizeof only tracked visible characters.",
+            "language": "c",
+        },
+    )
+    second = client.post(
+        "/smart/error-capture",
+        json={
+            "title": "sizeof versus strlen again",
+            "prompt": "I still mix up sizeof(arr) and strlen(arr) when reading C strings.",
+            "code": 'char arr[] = "abc"; printf("%zu %zu", sizeof(arr), strlen(arr));',
+            "user_analysis": "I keep treating storage size and logical string length as the same thing.",
+            "language": "c",
+        },
+    )
+    assert first.status_code == 200
+    assert second.status_code == 200
+
+    container = build_container(settings)
+    with container.session_factory() as session:
+        nodes = session.query(KnowledgeNode).all()
+        contrast_titles = [node.title for node in nodes if node.node_type == "contrast"]
+        concept_keys = [node.node_key for node in nodes if node.node_type == "concept"]
+        assert len(contrast_titles) == 1
+        assert len(concept_keys) == len(set(concept_keys))
+
+
+def test_smart_node_pack_builds_relations_between_related_errors() -> None:
+    root = make_test_dir("smart_node_pack")
+    settings = Settings(
+        _env_file=None,
+        obsidian_mode="filesystem",
+        vault_root=root / "vault",
+        sqlite_path=root / "db.sqlite3",
+        vector_store_path=root / "vectors.json",
+        smart_errors_folder="21 Errors",
+        smart_nodes_folder="20 Smart",
     )
     client = TestClient(create_app(settings))
 
@@ -81,58 +132,14 @@ def test_smart_error_capture_reuses_existing_supporting_nodes() -> None:
     second = client.post(
         "/smart/error-capture",
         json={
-            "title": "parameter decay again",
-            "prompt": "I still confuse array parameters with full arrays in C.",
-            "code": 'void g(int arr[3]) { printf("%zu", sizeof(arr)); }',
-            "user_analysis": "I repeated the same misunderstanding about array decay.",
+            "title": "array and pointer confusion",
+            "prompt": "I assumed arr and &arr had the same pointer type.",
+            "code": "int arr[4]; int *p = arr; int (*q)[4] = &arr;",
+            "user_analysis": "I collapsed array and pointer semantics together.",
             "language": "c",
         },
     )
     assert first.status_code == 200
-    assert second.status_code == 200
-
-    container = build_container(settings)
-    with container.session_factory() as session:
-        nodes = session.query(KnowledgeNode).all()
-        concept_keys = [node.node_key for node in nodes if node.node_type == "concept"]
-        pitfall_keys = [node.node_key for node in nodes if node.node_type == "pitfall"]
-        assert len(concept_keys) == len(set(concept_keys))
-        assert len(pitfall_keys) == len(set(pitfall_keys))
-
-
-def test_smart_node_pack_builds_relations_between_related_errors() -> None:
-    root = make_test_dir("smart_node_pack")
-    settings = Settings(
-        _env_file=None,
-        obsidian_mode="filesystem",
-        vault_root=root / "vault",
-        sqlite_path=root / "db.sqlite3",
-        vector_store_path=root / "vectors.json",
-        smart_errors_folder="21 Errors",
-    )
-    client = TestClient(create_app(settings))
-
-    first = client.post(
-        "/smart/error-capture",
-        json={
-            "title": "sizeof vs strlen confusion",
-            "prompt": "I treated sizeof(arr) as the visible string length.",
-            "code": 'char arr[] = "abc"; printf("%zu", sizeof(arr));',
-            "user_analysis": "I assumed sizeof only tracked visible characters.",
-            "language": "c",
-        },
-    )
-    assert first.status_code == 200
-    second = client.post(
-        "/smart/error-capture",
-        json={
-            "title": "strlen terminator confusion",
-            "prompt": "I expected strlen to count the null terminator.",
-            "code": 'char arr[] = "abc"; printf("%zu", strlen(arr));',
-            "user_analysis": "I mixed up string length and storage size.",
-            "language": "c",
-        },
-    )
     assert second.status_code == 200
 
     pack = client.post(
@@ -142,5 +149,4 @@ def test_smart_node_pack_builds_relations_between_related_errors() -> None:
     assert pack.status_code == 200
     payload = pack.json()
     assert payload["stored_edges"] >= 1
-    assert payload["pack"]["edges"][0]["relation_type"] == "commonly_confused_with"
-    assert "sizeof" in payload["pack"]["summary"].lower()
+    assert payload["pack"]["edges"]


### PR DESCRIPTION
# Summary
- extend smart capture to create deduplicated concept, pitfall, and contrast nodes
- add stronger novelty filtering using normalized titles and summaries in addition to node keys
- persist support-node edges and show generated nodes in the dashboard result

# Risk
- changes the smart capture response shape and node writing behavior
- novelty filtering is heuristic and intentionally conservative for this iteration

# Test Evidence
- ruff check src tests scripts --select F,E9,B
- python -m compileall src scripts tests
- pytest tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py tests/integration/test_smart_relink.py tests/integration/test_ui_routes.py tests/unit/test_app.py -q --basetemp data/test_runs/pytest_phase30_exec1
- real Ollama smoke: POST /smart/error-capture with Qwen14B-fixed:latest returned 200 and produced concept/pitfall/contrast nodes

# Rollback Plan
- Revert the squash merge commit from this PR.
