### PR TITLE
feat: implement issue #32 smart telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ python -m compileall src scripts
 - The built-in control panel is served from `/` and `/ui`.
 - The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, create relink reviews, search notes, inspect review items, and run maintenance jobs.
 - Smart error capture creates deduplicated support nodes for `concept`, `pitfall`, and `contrast` when the input suggests them.
+- Smart responses now include compact telemetry for provider routing, prompt size, response size, and token usage when the provider exposes usage data.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -78,6 +78,8 @@ curl -X POST http://127.0.0.1:8000/smart/teach ^
   -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5}"
 ```
 
+The smart endpoints now return a `telemetry` object with provider, model, prompt size, response size, and token usage when the active provider exposes usage data.
+
 To inspect nearby smart nodes without generating a teaching pack:
 
 ```bash

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -222,6 +222,7 @@ class SmartErrorCaptureResponse(BaseModel):
     related_nodes: list[KnowledgeNodeSchema] = Field(default_factory=list)
     action_preview: ActionPreview | None = None
     stored_edges: int = 0
+    telemetry: dict[str, object] = Field(default_factory=dict)
 
 
 class NodePackRequest(BaseModel):
@@ -232,6 +233,7 @@ class NodePackRequest(BaseModel):
 class SmartNodePackResponse(BaseModel):
     pack: RelationPack
     stored_edges: int = 0
+    telemetry: dict[str, object] = Field(default_factory=dict)
 
 
 class RelatedNodesRequest(BaseModel):
@@ -256,6 +258,7 @@ class TeachingPackResponse(BaseModel):
     sections: list[TeachingSection] = Field(default_factory=list)
     drills: list[str] = Field(default_factory=list)
     markdown: str
+    telemetry: dict[str, object] = Field(default_factory=dict)
 
 
 class SmartRelinkRequest(BaseModel):
@@ -272,3 +275,4 @@ class SmartRelinkResponse(BaseModel):
     review_id: int | None = None
     proposal_path: str | None = None
     action_preview: ActionPreview | None = None
+    telemetry: dict[str, object] = Field(default_factory=dict)

--- a/src/obsidian_agent/integrations/deepseek_client.py
+++ b/src/obsidian_agent/integrations/deepseek_client.py
@@ -50,4 +50,17 @@ class DeepSeekChatClient:
             )
         data = response.json()
         message_text = data["choices"][0]["message"]["content"]
-        return json.loads(message_text)
+        payload = json.loads(message_text)
+        usage = data.get("usage", {})
+        payload["_telemetry"] = {
+            "provider": "deepseek",
+            "model": data.get("model", self.model),
+            "prompt_chars": len(instructions) + len(input_text),
+            "response_chars": len(message_text),
+            "usage": {
+                "prompt_tokens": usage.get("prompt_tokens"),
+                "completion_tokens": usage.get("completion_tokens"),
+                "total_tokens": usage.get("total_tokens"),
+            },
+        }
+        return payload

--- a/src/obsidian_agent/integrations/ollama_client.py
+++ b/src/obsidian_agent/integrations/ollama_client.py
@@ -44,4 +44,16 @@ class OllamaChatClient:
             )
         data = response.json()
         message_text = data["message"]["content"]
-        return json.loads(message_text)
+        payload = json.loads(message_text)
+        payload["_telemetry"] = {
+            "provider": "ollama",
+            "model": data.get("model", self.model),
+            "prompt_chars": len(instructions) + len(input_text),
+            "response_chars": len(message_text),
+            "usage": {
+                "prompt_tokens": data.get("prompt_eval_count"),
+                "completion_tokens": data.get("eval_count"),
+                "total_tokens": (data.get("prompt_eval_count") or 0) + (data.get("eval_count") or 0),
+            },
+        }
+        return payload

--- a/src/obsidian_agent/integrations/openai_client.py
+++ b/src/obsidian_agent/integrations/openai_client.py
@@ -46,4 +46,17 @@ class OpenAIResponsesClient:
             )
         data = response.json()
         output_text = data["output"][0]["content"][0]["text"]
-        return json.loads(output_text)
+        payload = json.loads(output_text)
+        usage = data.get("usage", {})
+        payload["_telemetry"] = {
+            "provider": "openai",
+            "model": data.get("model", self.model),
+            "prompt_chars": len(instructions) + len(input_text),
+            "response_chars": len(output_text),
+            "usage": {
+                "prompt_tokens": usage.get("input_tokens"),
+                "completion_tokens": usage.get("output_tokens"),
+                "total_tokens": usage.get("total_tokens"),
+            },
+        }
+        return payload

--- a/src/obsidian_agent/services/context_compressor_service.py
+++ b/src/obsidian_agent/services/context_compressor_service.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import logging
+
 from obsidian_agent.domain.schemas import KnowledgeEdgeSchema, KnowledgeNodeSchema, RelationPack
 from obsidian_agent.services.routing_policy_service import RoutingPolicyService
+
+logger = logging.getLogger(__name__)
 
 
 class ContextCompressorService:
@@ -11,6 +15,7 @@ class ContextCompressorService:
 
     def __init__(self, routing_policy: RoutingPolicyService) -> None:
         self.routing_policy = routing_policy
+        self.last_telemetry: dict[str, object] = {}
 
     async def build_pack(
         self,
@@ -34,7 +39,7 @@ class ContextCompressorService:
     ) -> str:
         if not edges:
             return f"No high-confidence related nodes were found yet for {anchor.title}."
-        llm_service = self.routing_policy.for_structured_task()
+        llm_service = self.routing_policy.for_structured_task("context_compressor")
         raw = await llm_service.run_structured_task(
             instructions=(
                 "Return JSON with one key 'summary'. Summarize the anchor node and its highest-value relations "
@@ -53,6 +58,9 @@ class ContextCompressorService:
                 ]
             ),
         )
+        self.last_telemetry = llm_service.pop_telemetry()
+        if self.last_telemetry:
+            logger.info("smart_telemetry task=context_compressor telemetry=%s", self.last_telemetry)
         if isinstance(raw, dict) and str(raw.get("summary") or "").strip():
             return str(raw["summary"]).strip()
         top_edges = ", ".join(

--- a/src/obsidian_agent/services/error_extractor_service.py
+++ b/src/obsidian_agent/services/error_extractor_service.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import logging
+
 from obsidian_agent.domain.schemas import ErrorCaptureRequest, ErrorObject
 from obsidian_agent.services.llm_service import LLMService
 from obsidian_agent.utils.slugify import slugify
+
+logger = logging.getLogger(__name__)
 
 
 class ErrorExtractorService:
@@ -12,6 +16,7 @@ class ErrorExtractorService:
 
     def __init__(self, llm_service: LLMService) -> None:
         self.llm_service = llm_service
+        self.last_telemetry: dict[str, object] = {}
 
     async def extract(self, payload: ErrorCaptureRequest) -> ErrorObject:
         prompt_text = self._compose_input(payload)
@@ -23,6 +28,9 @@ class ErrorExtractorService:
             ),
             input_text=prompt_text,
         )
+        self.last_telemetry = self.llm_service.pop_telemetry()
+        if self.last_telemetry:
+            logger.info("smart_telemetry task=error_extract telemetry=%s", self.last_telemetry)
         if raw:
             return ErrorObject.model_validate(self._sanitize(raw, payload))
         return self._fallback(payload)

--- a/src/obsidian_agent/services/llm_service.py
+++ b/src/obsidian_agent/services/llm_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from typing import Protocol
 
 from obsidian_agent.domain.enums import ProposalType, SourceType
@@ -26,13 +27,41 @@ class LLMService:
 
     def __init__(self, client: JsonLLMClient | None = None) -> None:
         self.client = client
+        self._last_telemetry: dict[str, object] = {}
 
     async def run_structured_task(self, instructions: str, input_text: str) -> dict[str, object] | None:
         """Execute a structured generation task when a provider is available."""
 
         if not self.client:
+            self._last_telemetry = {
+                "provider": "offline",
+                "model": "offline-fallback",
+                "prompt_chars": len(instructions) + len(input_text),
+                "response_chars": 0,
+            }
             return None
-        return await self.client.create_json_response(instructions=instructions, input_text=input_text)
+        raw = await self.client.create_json_response(instructions=instructions, input_text=input_text)
+        if not isinstance(raw, dict):
+            self._last_telemetry = {}
+            return raw
+        telemetry = raw.pop("_telemetry", {})
+        if isinstance(telemetry, dict):
+            self._last_telemetry = telemetry
+        else:
+            self._last_telemetry = {}
+        return raw
+
+    def pop_telemetry(self) -> dict[str, object]:
+        telemetry = copy.deepcopy(self._last_telemetry)
+        self._last_telemetry = {}
+        return telemetry
+
+    def describe(self) -> dict[str, object]:
+        if not self.client:
+            return {"provider": "offline", "model": "offline-fallback"}
+        provider = self.client.__class__.__name__.replace("ChatClient", "").replace("ResponsesClient", "")
+        model = getattr(self.client, "model", "unknown")
+        return {"provider": provider.lower(), "model": model}
 
     async def normalize_capture(self, payload: CaptureInput) -> NormalizedCapture:
         """Return a structured capture payload."""

--- a/src/obsidian_agent/services/relation_miner_service.py
+++ b/src/obsidian_agent/services/relation_miner_service.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 from obsidian_agent.domain.enums import KnowledgeRelationType
 from obsidian_agent.domain.schemas import KnowledgeEdgeSchema, KnowledgeNodeSchema
 from obsidian_agent.services.routing_policy_service import RoutingPolicyService
+
+logger = logging.getLogger(__name__)
 
 
 class RelationMinerService:
@@ -15,6 +18,7 @@ class RelationMinerService:
 
     def __init__(self, routing_policy: RoutingPolicyService) -> None:
         self.routing_policy = routing_policy
+        self.last_telemetry: dict[str, object] = {}
 
     async def mine(
         self,
@@ -23,7 +27,7 @@ class RelationMinerService:
     ) -> list[KnowledgeEdgeSchema]:
         if not candidates:
             return []
-        llm_service = self.routing_policy.for_structured_task()
+        llm_service = self.routing_policy.for_structured_task("relation_miner")
         raw = await llm_service.run_structured_task(
             instructions=(
                 "Return JSON with a top-level key 'relations' containing a list of objects with keys: "
@@ -33,6 +37,9 @@ class RelationMinerService:
             ),
             input_text=self._compose_input(anchor, candidates),
         )
+        self.last_telemetry = llm_service.pop_telemetry()
+        if self.last_telemetry:
+            logger.info("smart_telemetry task=relation_miner telemetry=%s", self.last_telemetry)
         relations = self._sanitize(raw, anchor, candidates)
         if relations:
             return relations

--- a/src/obsidian_agent/services/routing_policy_service.py
+++ b/src/obsidian_agent/services/routing_policy_service.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import logging
+
 from obsidian_agent.services.llm_service import LLMService
+
+logger = logging.getLogger(__name__)
 
 
 class RoutingPolicyService:
@@ -12,14 +16,20 @@ class RoutingPolicyService:
         self.primary_llm_service = primary_llm_service
         self.local_llm_service = local_llm_service
 
-    def for_structured_task(self) -> LLMService:
+    def for_structured_task(self, task_name: str = "structured") -> LLMService:
         if self.local_llm_service and self.local_llm_service.client is not None:
-            return self.local_llm_service
-        return self.primary_llm_service
+            service = self.local_llm_service
+        else:
+            service = self.primary_llm_service
+        logger.info("smart_route task=%s provider=%s model=%s", task_name, service.describe()["provider"], service.describe()["model"])
+        return service
 
-    def for_teaching_task(self) -> LLMService:
+    def for_teaching_task(self, task_name: str = "teaching") -> LLMService:
         if self.primary_llm_service and self.primary_llm_service.client is not None:
-            return self.primary_llm_service
-        if self.local_llm_service and self.local_llm_service.client is not None:
-            return self.local_llm_service
-        return self.primary_llm_service
+            service = self.primary_llm_service
+        elif self.local_llm_service and self.local_llm_service.client is not None:
+            service = self.local_llm_service
+        else:
+            service = self.primary_llm_service
+        logger.info("smart_route task=%s provider=%s model=%s", task_name, service.describe()["provider"], service.describe()["model"])
+        return service

--- a/src/obsidian_agent/services/smart_capture_service.py
+++ b/src/obsidian_agent/services/smart_capture_service.py
@@ -36,4 +36,9 @@ class SmartCaptureService:
             related_nodes=related_nodes,
             action_preview=action_preview,
             stored_edges=stored_edges,
+            telemetry={
+                "error_extractor": self.error_extractor.last_telemetry,
+                "weakness_count": len(weaknesses),
+                "related_node_count": len(related_nodes),
+            },
         )

--- a/src/obsidian_agent/services/smart_node_pack_service.py
+++ b/src/obsidian_agent/services/smart_node_pack_service.py
@@ -62,7 +62,16 @@ class SmartNodePackService:
                     if item.id is not None
                 },
             )
-        return SmartNodePackResponse(pack=pack, stored_edges=len(stored))
+        return SmartNodePackResponse(
+            pack=pack,
+            stored_edges=len(stored),
+            telemetry={
+                "relation_miner": self.relation_miner.last_telemetry,
+                "context_compressor": self.context_compressor.last_telemetry,
+                "candidate_count": len(candidates),
+                "related_count": len(related_nodes),
+            },
+        )
 
     def _to_schema(self, entity) -> KnowledgeNodeSchema:
         tags = json.loads(entity.tags_json or "[]")

--- a/src/obsidian_agent/services/smart_relink_service.py
+++ b/src/obsidian_agent/services/smart_relink_service.py
@@ -47,6 +47,7 @@ class SmartRelinkService:
                 related_section_markdown=related_section_markdown,
                 stored_edges=pack_response.stored_edges,
                 action_preview=preview,
+                telemetry=pack_response.telemetry,
             )
 
         proposal = ReviewProposal(
@@ -66,6 +67,7 @@ class SmartRelinkService:
             stored_edges=pack_response.stored_edges,
             review_id=review_id,
             proposal_path=proposal_path,
+            telemetry=pack_response.telemetry,
         )
 
     def _render_related_section(self, pack) -> str:

--- a/src/obsidian_agent/services/teaching_planner_service.py
+++ b/src/obsidian_agent/services/teaching_planner_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from obsidian_agent.domain.schemas import (
     RelationPack,
     TeachingPackRequest,
@@ -10,6 +12,8 @@ from obsidian_agent.domain.schemas import (
 )
 from obsidian_agent.services.routing_policy_service import RoutingPolicyService
 from obsidian_agent.services.smart_node_pack_service import SmartNodePackService
+
+logger = logging.getLogger(__name__)
 
 
 class TeachingPlannerService:
@@ -22,6 +26,7 @@ class TeachingPlannerService:
     ) -> None:
         self.smart_node_pack_service = smart_node_pack_service
         self.routing_policy = routing_policy
+        self.last_telemetry: dict[str, object] = {}
 
     async def build_teaching_pack(self, request: TeachingPackRequest) -> TeachingPackResponse:
         pack_response = await self.smart_node_pack_service.build_node_pack(
@@ -45,10 +50,14 @@ class TeachingPlannerService:
             sections=payload["sections"],
             drills=payload["drills"],
             markdown=markdown,
+            telemetry={
+                "planner": self.last_telemetry,
+                "pack": pack_response.telemetry,
+            },
         )
 
     async def _plan_from_model(self, pack: RelationPack) -> dict[str, object] | None:
-        llm_service = self.routing_policy.for_teaching_task()
+        llm_service = self.routing_policy.for_teaching_task("teaching_planner")
         raw = await llm_service.run_structured_task(
             instructions=(
                 "Return JSON with keys: title, overview, sections, drills. "
@@ -71,6 +80,9 @@ class TeachingPlannerService:
                 ]
             ),
         )
+        self.last_telemetry = llm_service.pop_telemetry()
+        if self.last_telemetry:
+            logger.info("smart_telemetry task=teaching_planner telemetry=%s", self.last_telemetry)
         if not isinstance(raw, dict):
             return None
         title = str(raw.get("title") or "").strip()

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -347,6 +347,9 @@ function renderSmartResult(payload) {
     ? `<small>review #${payload.review_id}: ${payload.proposal_path || ""}</small>`
     : "";
   const edgeMeta = payload.stored_edges ? `<small>stored edges: ${payload.stored_edges}</small>` : "";
+  const telemetryMeta = payload.telemetry && Object.keys(payload.telemetry).length
+    ? `<small>telemetry: ${JSON.stringify(payload.telemetry)}</small>`
+    : "";
   target.innerHTML = `
     <article class="result-card">
       <strong>${title}</strong>
@@ -355,6 +358,7 @@ function renderSmartResult(payload) {
       <ul>${listHtml}</ul>
       ${preview}
       ${edgeMeta}
+      ${telemetryMeta}
       ${reviewMeta}
       ${markdown}
     </article>

--- a/tests/integration/test_smart_capture.py
+++ b/tests/integration/test_smart_capture.py
@@ -39,6 +39,8 @@ def test_smart_error_capture_creates_supporting_nodes_and_edges() -> None:
     assert payload["related_nodes"]
     assert payload["stored_edges"] >= 2
     assert any(item["node_type"] == "contrast" for item in payload["related_nodes"])
+    assert "telemetry" in payload
+    assert "error_extractor" in payload["telemetry"]
 
     error_note_path = payload["node"]["note_path"]
     assert error_note_path.startswith("21 Errors/")
@@ -150,3 +152,5 @@ def test_smart_node_pack_builds_relations_between_related_errors() -> None:
     payload = pack.json()
     assert payload["stored_edges"] >= 1
     assert payload["pack"]["edges"]
+    assert "telemetry" in payload
+    assert "relation_miner" in payload["telemetry"]

--- a/tests/integration/test_smart_teaching.py
+++ b/tests/integration/test_smart_teaching.py
@@ -50,6 +50,7 @@ def test_smart_teach_returns_markdown_and_sections() -> None:
     assert payload["sections"]
     assert payload["markdown"].startswith("# ")
     assert "## Practice Drills" in payload["markdown"]
+    assert "telemetry" in payload
 
 
 def test_smart_related_nodes_returns_related_entries() -> None:


### PR DESCRIPTION
# Summary
- add smart telemetry for provider routing, prompt/response size, and token usage when providers expose usage data
- log smart routing decisions for extractor, relation miner, context compressor, and teaching planner
- surface telemetry in smart API responses and dashboard output

# Risk
- changes smart response payloads by adding telemetry objects
- token usage depends on provider-specific fields and may be partial for some backends

# Test Evidence
- ruff check src tests scripts --select F,E9,B
- python -m compileall src scripts tests
- pytest tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py tests/integration/test_smart_relink.py tests/integration/test_ui_routes.py tests/unit/test_app.py -q --basetemp data/test_runs/pytest_phase32_exec1
- real Ollama smoke: /smart/error-capture and /smart/teach returned telemetry with token counts

# Rollback Plan
- Revert the squash merge commit from this PR.
