### PR TITLE
feat(smart): implement issue #34 teaching routing controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ python -m compileall src scripts
 - The control panel can edit `.env`, reload runtime settings, seed demo data, reindex, capture text, run smart C-error capture, preview node packs, build teaching packs, create relink reviews, search notes, inspect review items, and run maintenance jobs.
 - Smart error capture creates deduplicated support nodes for `concept`, `pitfall`, and `contrast` when the input suggests them.
 - Smart responses now include compact telemetry for provider routing, prompt size, response size, and token usage when the provider exposes usage data.
+- Teaching packs now accept `delivery_mode=auto|local|remote` and expose the resolved route, token budget hint, and condensed context size in telemetry.
 - `/capture/url` blocks loopback and private-network targets to reduce SSRF risk.
 
 See [docs/operations.md](/W:/codex/codex/docs/operations.md), [docs/api.md](/W:/codex/codex/docs/api.md), and [docs/prompts.md](/W:/codex/codex/docs/prompts.md) for details.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -75,10 +75,10 @@ To generate a teaching-oriented explanation from that relation pack:
 ```bash
 curl -X POST http://127.0.0.1:8000/smart/teach ^
   -H "Content-Type: application/json" ^
-  -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5}"
+  -d "{\"node_key\":\"error/sizeof-vs-strlen\",\"top_k\":5,\"delivery_mode\":\"local\"}"
 ```
 
-The smart endpoints now return a `telemetry` object with provider, model, prompt size, response size, and token usage when the active provider exposes usage data.
+The smart endpoints now return a `telemetry` object with provider, model, prompt size, response size, and token usage when the active provider exposes usage data. `POST /smart/teach` also reports the requested and resolved delivery mode plus the relation pack token budget hint.
 
 To inspect nearby smart nodes without generating a teaching pack:
 

--- a/src/obsidian_agent/domain/schemas.py
+++ b/src/obsidian_agent/domain/schemas.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -213,6 +214,12 @@ class RelationPack(BaseModel):
     related_nodes: list[KnowledgeNodeSchema] = Field(default_factory=list)
     edges: list[KnowledgeEdgeSchema] = Field(default_factory=list)
     summary: str = ""
+    relation_summary: str = ""
+    weakness_labels: list[str] = Field(default_factory=list)
+    do_not_repeat: list[str] = Field(default_factory=list)
+    recommended_output_shape: str = "teaching_note"
+    token_budget_hint: int = 800
+    condensed_context: str = ""
 
 
 class SmartErrorCaptureResponse(BaseModel):
@@ -244,6 +251,7 @@ class RelatedNodesRequest(BaseModel):
 class TeachingPackRequest(BaseModel):
     node_key: str = Field(min_length=3)
     top_k: int = Field(default=5, ge=1, le=10)
+    delivery_mode: Literal["auto", "local", "remote"] = "auto"
 
 
 class TeachingSection(BaseModel):
@@ -258,6 +266,7 @@ class TeachingPackResponse(BaseModel):
     sections: list[TeachingSection] = Field(default_factory=list)
     drills: list[str] = Field(default_factory=list)
     markdown: str
+    delivery_mode: str = "auto"
     telemetry: dict[str, object] = Field(default_factory=dict)
 
 

--- a/src/obsidian_agent/services/context_compressor_service.py
+++ b/src/obsidian_agent/services/context_compressor_service.py
@@ -23,12 +23,20 @@ class ContextCompressorService:
         related_nodes: list[KnowledgeNodeSchema],
         edges: list[KnowledgeEdgeSchema],
     ) -> RelationPack:
-        summary = await self._summarize(anchor, related_nodes, edges)
+        fallback = self._fallback_fields(anchor, related_nodes, edges)
+        payload = await self._summarize(anchor, related_nodes, edges)
+        fields = self._sanitize_payload(payload, fallback)
         return RelationPack(
             anchor=anchor,
             related_nodes=related_nodes,
             edges=edges,
-            summary=summary,
+            summary=fields["summary"],
+            relation_summary=fields["relation_summary"],
+            weakness_labels=fields["weakness_labels"],
+            do_not_repeat=fields["do_not_repeat"],
+            recommended_output_shape=fields["recommended_output_shape"],
+            token_budget_hint=fields["token_budget_hint"],
+            condensed_context=fields["condensed_context"],
         )
 
     async def _summarize(
@@ -36,18 +44,22 @@ class ContextCompressorService:
         anchor: KnowledgeNodeSchema,
         related_nodes: list[KnowledgeNodeSchema],
         edges: list[KnowledgeEdgeSchema],
-    ) -> str:
+    ) -> dict[str, object] | None:
         if not edges:
-            return f"No high-confidence related nodes were found yet for {anchor.title}."
+            return None
         llm_service = self.routing_policy.for_structured_task("context_compressor")
         raw = await llm_service.run_structured_task(
             instructions=(
-                "Return JSON with one key 'summary'. Summarize the anchor node and its highest-value relations "
-                "for a teaching or review workflow in 2-4 sentences."
+                "Return JSON with keys: summary, relation_summary, weakness_labels, do_not_repeat, "
+                "recommended_output_shape, token_budget_hint, condensed_context. "
+                "Summarize the anchor node and its highest-value relations for a teaching workflow. "
+                "Keep condensed_context concise, include only the highest-value context, and set "
+                "recommended_output_shape to a short label like teaching_note or teaching_note_with_drills."
             ),
             input_text="\n".join(
                 [
                     f"Anchor: {anchor.title} - {anchor.summary}",
+                    f"Anchor metadata: {anchor.metadata}",
                     "Related nodes:",
                     *[f"- {item.title}: {item.summary}" for item in related_nodes],
                     "Relations:",
@@ -61,9 +73,97 @@ class ContextCompressorService:
         self.last_telemetry = llm_service.pop_telemetry()
         if self.last_telemetry:
             logger.info("smart_telemetry task=context_compressor telemetry=%s", self.last_telemetry)
-        if isinstance(raw, dict) and str(raw.get("summary") or "").strip():
-            return str(raw["summary"]).strip()
-        top_edges = ", ".join(
-            f"{edge.relation_type.value} {edge.to_node_key}" for edge in edges[:3]
-        )
-        return f"{anchor.title} links to {len(edges)} related nodes. Priority relations: {top_edges}."
+        return raw if isinstance(raw, dict) else None
+
+    def _sanitize_payload(
+        self,
+        raw: dict[str, object] | None,
+        fallback: dict[str, object],
+    ) -> dict[str, object]:
+        data = dict(fallback)
+        if not raw:
+            return data
+        summary = str(raw.get("summary") or "").strip()
+        relation_summary = str(raw.get("relation_summary") or "").strip()
+        condensed_context = str(raw.get("condensed_context") or "").strip()
+        recommended_output_shape = str(raw.get("recommended_output_shape") or "").strip()
+        if summary:
+            data["summary"] = summary
+        if relation_summary:
+            data["relation_summary"] = relation_summary
+        if condensed_context:
+            data["condensed_context"] = condensed_context
+        if recommended_output_shape:
+            data["recommended_output_shape"] = recommended_output_shape
+        weakness_labels = raw.get("weakness_labels")
+        if isinstance(weakness_labels, list):
+            data["weakness_labels"] = [str(item).strip() for item in weakness_labels if str(item).strip()]
+        do_not_repeat = raw.get("do_not_repeat")
+        if isinstance(do_not_repeat, list):
+            data["do_not_repeat"] = [str(item).strip() for item in do_not_repeat if str(item).strip()]
+        try:
+            token_budget_hint = int(raw.get("token_budget_hint", data["token_budget_hint"]))
+        except (TypeError, ValueError):
+            token_budget_hint = int(data["token_budget_hint"])
+        data["token_budget_hint"] = max(300, min(2400, token_budget_hint))
+        return data
+
+    def _fallback_fields(
+        self,
+        anchor: KnowledgeNodeSchema,
+        related_nodes: list[KnowledgeNodeSchema],
+        edges: list[KnowledgeEdgeSchema],
+    ) -> dict[str, object]:
+        top_edges = ", ".join(f"{edge.relation_type.value} {edge.to_node_key}" for edge in edges[:3])
+        weakness_labels = self._extract_weakness_labels(anchor)
+        do_not_repeat: list[str] = []
+        incorrect_assumption = str(anchor.metadata.get("incorrect_assumption", "")).strip()
+        if incorrect_assumption:
+            do_not_repeat.append(f"Do not repeat the incorrect assumption: {incorrect_assumption}")
+        if edges:
+            do_not_repeat.append("Do not restate every related note; only keep the highest-value contrasts and prerequisites.")
+        condensed_parts = [
+            f"Anchor: {anchor.title}",
+            f"Summary: {anchor.summary}",
+        ]
+        if weakness_labels:
+            condensed_parts.append(f"Weaknesses: {', '.join(weakness_labels[:3])}")
+        if related_nodes:
+            condensed_parts.append(
+                "Related: " + "; ".join(f"{item.title} ({item.node_type.value})" for item in related_nodes[:4])
+            )
+        if edges:
+            condensed_parts.append(
+                "Relations: " + "; ".join(
+                    f"{edge.relation_type.value} -> {edge.to_node_key}" for edge in edges[:4]
+                )
+            )
+        condensed_context = " | ".join(condensed_parts)
+        token_budget_hint = max(450, min(1800, 280 + len(condensed_context) // 2))
+        return {
+            "summary": (
+                f"{anchor.title} links to {len(edges)} related nodes. Priority relations: {top_edges}."
+                if edges
+                else f"No high-confidence related nodes were found yet for {anchor.title}."
+            ),
+            "relation_summary": top_edges or "No priority relations yet.",
+            "weakness_labels": weakness_labels,
+            "do_not_repeat": do_not_repeat,
+            "recommended_output_shape": "teaching_note_with_drills" if edges else "teaching_note",
+            "token_budget_hint": token_budget_hint,
+            "condensed_context": condensed_context,
+        }
+
+    def _extract_weakness_labels(self, anchor: KnowledgeNodeSchema) -> list[str]:
+        raw = anchor.metadata.get("weaknesses")
+        if not isinstance(raw, list):
+            return []
+        labels: list[str] = []
+        for item in raw:
+            if isinstance(item, dict):
+                label = str(item.get("name") or "").strip()
+            else:
+                label = str(item).strip()
+            if label:
+                labels.append(label)
+        return labels[:5]

--- a/src/obsidian_agent/services/routing_policy_service.py
+++ b/src/obsidian_agent/services/routing_policy_service.py
@@ -24,12 +24,41 @@ class RoutingPolicyService:
         logger.info("smart_route task=%s provider=%s model=%s", task_name, service.describe()["provider"], service.describe()["model"])
         return service
 
-    def for_teaching_task(self, task_name: str = "teaching") -> LLMService:
-        if self.primary_llm_service and self.primary_llm_service.client is not None:
-            service = self.primary_llm_service
-        elif self.local_llm_service and self.local_llm_service.client is not None:
-            service = self.local_llm_service
+    def for_teaching_task(self, task_name: str = "teaching", delivery_mode: str = "auto") -> tuple[LLMService, str]:
+        requested = delivery_mode.lower().strip() or "auto"
+        primary_available = self.primary_llm_service.client is not None
+        local_available = self.local_llm_service is not None and self.local_llm_service.client is not None
+        service = self.primary_llm_service
+        resolved = "offline"
+
+        if requested == "local":
+            if local_available:
+                service = self.local_llm_service
+                resolved = "local"
+            elif primary_available:
+                service = self.primary_llm_service
+                resolved = "remote-fallback"
+        elif requested == "remote":
+            if primary_available:
+                service = self.primary_llm_service
+                resolved = "remote"
+            elif local_available:
+                service = self.local_llm_service
+                resolved = "local-fallback"
         else:
-            service = self.primary_llm_service
-        logger.info("smart_route task=%s provider=%s model=%s", task_name, service.describe()["provider"], service.describe()["model"])
-        return service
+            if primary_available:
+                service = self.primary_llm_service
+                resolved = "remote"
+            elif local_available:
+                service = self.local_llm_service
+                resolved = "local"
+
+        logger.info(
+            "smart_route task=%s requested=%s resolved=%s provider=%s model=%s",
+            task_name,
+            requested,
+            resolved,
+            service.describe()["provider"],
+            service.describe()["model"],
+        )
+        return service, resolved

--- a/src/obsidian_agent/services/smart_node_pack_service.py
+++ b/src/obsidian_agent/services/smart_node_pack_service.py
@@ -70,6 +70,8 @@ class SmartNodePackService:
                 "context_compressor": self.context_compressor.last_telemetry,
                 "candidate_count": len(candidates),
                 "related_count": len(related_nodes),
+                "token_budget_hint": pack.token_budget_hint,
+                "condensed_context_chars": len(pack.condensed_context),
             },
         )
 

--- a/src/obsidian_agent/services/teaching_planner_service.py
+++ b/src/obsidian_agent/services/teaching_planner_service.py
@@ -34,9 +34,11 @@ class TeachingPlannerService:
             top_k=request.top_k,
         )
         pack = pack_response.pack
-        payload = await self._plan_from_model(pack)
+        payload, resolved_mode = await self._plan_from_model(pack, request.delivery_mode)
         if payload is None:
             payload = self._fallback_plan(pack)
+            if resolved_mode == "offline":
+                resolved_mode = "offline-fallback"
         markdown = self._render_markdown(
             title=payload["title"],
             overview=payload["overview"],
@@ -50,33 +52,44 @@ class TeachingPlannerService:
             sections=payload["sections"],
             drills=payload["drills"],
             markdown=markdown,
+            delivery_mode=resolved_mode,
             telemetry={
+                "delivery_mode_requested": request.delivery_mode,
+                "delivery_mode_resolved": resolved_mode,
+                "pack_token_budget_hint": pack.token_budget_hint,
+                "pack_context_chars": len(pack.condensed_context),
                 "planner": self.last_telemetry,
                 "pack": pack_response.telemetry,
             },
         )
 
-    async def _plan_from_model(self, pack: RelationPack) -> dict[str, object] | None:
-        llm_service = self.routing_policy.for_teaching_task("teaching_planner")
+    async def _plan_from_model(
+        self,
+        pack: RelationPack,
+        delivery_mode: str,
+    ) -> tuple[dict[str, object] | None, str]:
+        llm_service, resolved_mode = self.routing_policy.for_teaching_task(
+            "teaching_planner",
+            delivery_mode=delivery_mode,
+        )
         raw = await llm_service.run_structured_task(
             instructions=(
                 "Return JSON with keys: title, overview, sections, drills. "
                 "sections must be a list of objects with heading and body. "
                 "drills must be a list of short practice prompts. "
-                "Focus on teaching the anchor concept using the related nodes and relations."
+                "Focus on teaching the anchor concept using the condensed relation pack. "
+                f"Stay within roughly {pack.token_budget_hint} tokens of useful teaching content. "
+                f"Preferred output shape: {pack.recommended_output_shape}. "
+                f"Avoid repetition using these constraints: {'; '.join(pack.do_not_repeat) or 'none'}."
             ),
             input_text="\n".join(
                 [
                     f"Anchor: {pack.anchor.title}",
                     f"Anchor summary: {pack.anchor.summary}",
                     f"Relation summary: {pack.summary}",
-                    "Related nodes:",
-                    *[f"- {node.title}: {node.summary}" for node in pack.related_nodes],
-                    "Edges:",
-                    *[
-                        f"- {edge.relation_type.value} -> {edge.to_node_key}: {edge.reason}"
-                        for edge in pack.edges
-                    ],
+                    f"Condensed context: {pack.condensed_context}",
+                    f"Weakness labels: {', '.join(pack.weakness_labels) or 'none'}",
+                    f"Do not repeat: {'; '.join(pack.do_not_repeat) or 'none'}",
                 ]
             ),
         )
@@ -84,7 +97,7 @@ class TeachingPlannerService:
         if self.last_telemetry:
             logger.info("smart_telemetry task=teaching_planner telemetry=%s", self.last_telemetry)
         if not isinstance(raw, dict):
-            return None
+            return None, resolved_mode
         title = str(raw.get("title") or "").strip()
         overview = str(raw.get("overview") or "").strip()
         sections_raw = raw.get("sections")
@@ -102,13 +115,16 @@ class TeachingPlannerService:
         if isinstance(drills_raw, list):
             drills = [str(item).strip() for item in drills_raw if str(item).strip()]
         if not title or not overview or not sections:
-            return None
-        return {
-            "title": title,
-            "overview": overview,
-            "sections": sections,
-            "drills": drills[:5],
-        }
+            return None, resolved_mode
+        return (
+            {
+                "title": title,
+                "overview": overview,
+                "sections": sections,
+                "drills": drills[:5],
+            },
+            resolved_mode,
+        )
 
     def _fallback_plan(self, pack: RelationPack) -> dict[str, object]:
         related_titles = ", ".join(node.title for node in pack.related_nodes[:3]) or "nearby concepts"
@@ -126,16 +142,23 @@ class TeachingPlannerService:
             sections.append(
                 TeachingSection(
                     heading="Common Failure Mode",
-                    body=pack.edges[0].reason,
+                    body=str(pack.anchor.metadata.get("incorrect_assumption") or pack.edges[0].reason),
                 )
             )
         drills = [
             f"Explain {pack.anchor.title} in your own words.",
             f"Write one C example that avoids the mistake behind {pack.anchor.title}.",
         ]
+        if pack.weakness_labels:
+            sections.append(
+                TeachingSection(
+                    heading="Weakness Focus",
+                    body=", ".join(pack.weakness_labels),
+                )
+            )
         return {
             "title": f"Teaching Pack: {pack.anchor.title}",
-            "overview": pack.summary or pack.anchor.summary,
+            "overview": pack.relation_summary or pack.summary or pack.anchor.summary,
             "sections": sections,
             "drills": drills,
         }

--- a/src/obsidian_agent/ui/app.js
+++ b/src/obsidian_agent/ui/app.js
@@ -64,6 +64,9 @@ const translations = {
     runNodePack: "生成 Node Pack",
     runTeachPack: "生成 Teaching Pack",
     runRelink: "生成 Relink Review",
+    teachingModeAuto: "自动",
+    teachingModeLocal: "本地",
+    teachingModeRemote: "远端",
     search: "搜索",
     searchPlaceholder: "搜索笔记",
     runSearch: "执行搜索",
@@ -160,6 +163,9 @@ const translations = {
     runNodePack: "Build Node Pack",
     runTeachPack: "Build Teaching Pack",
     runRelink: "Build Relink Review",
+    teachingModeAuto: "Auto",
+    teachingModeLocal: "Local",
+    teachingModeRemote: "Remote",
     search: "Search",
     searchPlaceholder: "Search notes",
     runSearch: "Run Search",
@@ -347,6 +353,12 @@ function renderSmartResult(payload) {
     ? `<small>review #${payload.review_id}: ${payload.proposal_path || ""}</small>`
     : "";
   const edgeMeta = payload.stored_edges ? `<small>stored edges: ${payload.stored_edges}</small>` : "";
+  const packMeta = payload.pack
+    ? `<small>shape: ${payload.pack.recommended_output_shape || "-"} · budget: ${payload.pack.token_budget_hint || "-"}</small>`
+    : "";
+  const deliveryMeta = payload.delivery_mode
+    ? `<small>delivery: ${payload.delivery_mode}</small>`
+    : "";
   const telemetryMeta = payload.telemetry && Object.keys(payload.telemetry).length
     ? `<small>telemetry: ${JSON.stringify(payload.telemetry)}</small>`
     : "";
@@ -358,6 +370,8 @@ function renderSmartResult(payload) {
       <ul>${listHtml}</ul>
       ${preview}
       ${edgeMeta}
+      ${packMeta}
+      ${deliveryMeta}
       ${telemetryMeta}
       ${reviewMeta}
       ${markdown}
@@ -482,6 +496,7 @@ document.getElementById("teachSubmit").addEventListener("click", async () => {
     body: JSON.stringify({
       node_key: document.getElementById("nodePackKey").value,
       top_k: 5,
+      delivery_mode: document.getElementById("teachMode").value,
     }),
   });
   renderSmartResult(payload);

--- a/src/obsidian_agent/ui/index.html
+++ b/src/obsidian_agent/ui/index.html
@@ -124,7 +124,14 @@
               <input id="nodePackKey" data-i18n-placeholder="nodePackPlaceholder" placeholder="输入 node_key，例如 error/sizeof-vs-strlen">
               <button id="nodePackSubmit" class="secondary-button" data-i18n="runNodePack">生成 Node Pack</button>
             </div>
-            <button id="teachSubmit" class="secondary-button" data-i18n="runTeachPack">生成 Teaching Pack</button>
+            <div class="inline-form">
+              <select id="teachMode" aria-label="Teaching mode">
+                <option value="auto" data-i18n="teachingModeAuto">自动</option>
+                <option value="local" data-i18n="teachingModeLocal">本地</option>
+                <option value="remote" data-i18n="teachingModeRemote">远端</option>
+              </select>
+              <button id="teachSubmit" class="secondary-button" data-i18n="runTeachPack">生成 Teaching Pack</button>
+            </div>
             <button id="relinkSubmit" class="secondary-button" data-i18n="runRelink">生成 Relink Review</button>
             <div id="smartResults" class="result-list"></div>
           </div>

--- a/tests/integration/test_smart_capture.py
+++ b/tests/integration/test_smart_capture.py
@@ -152,5 +152,8 @@ def test_smart_node_pack_builds_relations_between_related_errors() -> None:
     payload = pack.json()
     assert payload["stored_edges"] >= 1
     assert payload["pack"]["edges"]
+    assert payload["pack"]["recommended_output_shape"]
+    assert payload["pack"]["token_budget_hint"] >= 300
+    assert payload["pack"]["condensed_context"]
     assert "telemetry" in payload
     assert "relation_miner" in payload["telemetry"]

--- a/tests/integration/test_smart_teaching.py
+++ b/tests/integration/test_smart_teaching.py
@@ -42,7 +42,7 @@ def test_smart_teach_returns_markdown_and_sections() -> None:
 
     response = client.post(
         "/smart/teach",
-        json={"node_key": first.json()["node"]["node_key"], "top_k": 5},
+        json={"node_key": first.json()["node"]["node_key"], "top_k": 5, "delivery_mode": "remote"},
     )
     assert response.status_code == 200
     payload = response.json()
@@ -51,6 +51,12 @@ def test_smart_teach_returns_markdown_and_sections() -> None:
     assert payload["markdown"].startswith("# ")
     assert "## Practice Drills" in payload["markdown"]
     assert "telemetry" in payload
+    assert payload["delivery_mode"] in {"remote", "local-fallback", "offline-fallback"}
+    assert payload["telemetry"]["delivery_mode_requested"] == "remote"
+    assert payload["telemetry"]["pack_token_budget_hint"] >= 300
+    assert payload["pack"]["recommended_output_shape"]
+    assert payload["pack"]["condensed_context"]
+    assert isinstance(payload["pack"]["do_not_repeat"], list)
 
 
 def test_smart_related_nodes_returns_related_entries() -> None:


### PR DESCRIPTION
## Summary
- add richer relation-pack fields for condensed teaching context
- support `delivery_mode=auto|local|remote` on `/smart/teach`
- surface resolved routing, budget hints, and condensed context telemetry in UI and API
- extend smart integration tests and walkthrough docs

## Verification
- `ruff check src tests --select F,E9,B`
- `python -m compileall src tests`
- `pytest tests/integration/test_smart_capture.py tests/integration/test_smart_teaching.py tests/integration/test_smart_relink.py tests/integration/test_ui_routes.py tests/unit/test_app.py -q --basetemp data/test_runs/pytest_phase34_exec1`
- real Ollama smoke with `Qwen14B-fixed:latest` for `/smart/error-capture` and `/smart/teach`
